### PR TITLE
Raise on missing assigns

### DIFF
--- a/lib/phoenix_html/engine.ex
+++ b/lib/phoenix_html/engine.ex
@@ -7,7 +7,19 @@ defmodule Phoenix.HTML.Engine do
   use EEx.Engine
 
   @doc false
-  def handle_body(body), do: body
+  def handle_body(body) do
+    Macro.postwalk(body, &postwalk_body/1)
+  end
+  defp postwalk_body({{:., [line: line], [{:__aliases__, _, [:Dict]}, :get]}, _,
+                      [{:var!, [_, context: EEx.Engine, import: Kernel],
+                        [{:assigns, _, EEx.Engine}]}, assign]}) do
+
+    {{:., [line: line], [{:__aliases__, [line: line, alias: false], [:Dict]}, :fetch!]},
+      [line: line],
+      [{:var!, [line: line, context: EEx.Engine, import: Kernel],
+        [{:assigns, [line: line], EEx.Engine}]}, assign]}
+  end
+  defp postwalk_body(segment), do: segment
 
   @doc false
   def handle_text(buffer, text) do

--- a/lib/phoenix_html/engine.ex
+++ b/lib/phoenix_html/engine.ex
@@ -83,7 +83,7 @@ defmodule Phoenix.HTML.Engine do
     case Dict.fetch(assigns, key) do
       :error ->
         raise ArgumentError, message: """
-        assign @#{key} not available in eex template assigns: #{inspect Dict.keys(assigns)}
+        assign @#{key} not available in eex template. Available assigns: #{inspect Dict.keys(assigns)}
         """
       {:ok, val} -> val
     end

--- a/lib/phoenix_html/engine.ex
+++ b/lib/phoenix_html/engine.ex
@@ -7,19 +7,7 @@ defmodule Phoenix.HTML.Engine do
   use EEx.Engine
 
   @doc false
-  def handle_body(body) do
-    Macro.postwalk(body, &postwalk_body/1)
-  end
-  defp postwalk_body({{:., [line: line], [{:__aliases__, _, [:Dict]}, :get]}, _,
-                      [{:var!, [_, context: EEx.Engine, import: Kernel],
-                        [{:assigns, _, EEx.Engine}]}, assign]}) do
-
-    {{:., [line: line], [{:__aliases__, [line: line, alias: false], [:Dict]}, :fetch!]},
-      [line: line],
-      [{:var!, [line: line, context: EEx.Engine, import: Kernel],
-        [{:assigns, [line: line], EEx.Engine}]}, assign]}
-  end
-  defp postwalk_body(segment), do: segment
+  def handle_body(body), do: body
 
   @doc false
   def handle_text(buffer, text) do
@@ -81,7 +69,24 @@ defmodule Phoenix.HTML.Engine do
   end
 
   defp expr(expr) do
-    Macro.prewalk(expr, &EEx.Engine.handle_assign/1)
+    Macro.prewalk(expr, &handle_assign/1)
+  end
+  defp handle_assign({:@, meta, [{name, _, atom}]}) when is_atom(name) and is_atom(atom) do
+    quote line: meta[:line] || 0 do
+      Phoenix.HTML.Engine.fetch_assign(var!(assigns), unquote(name))
+    end
+  end
+  defp handle_assign(arg), do: arg
+
+  @doc false
+  def fetch_assign(assigns, key) do
+    case Dict.fetch(assigns, key) do
+      :error ->
+        raise ArgumentError, message: """
+        assign @#{key} not available in eex template assigns: #{inspect Dict.keys(assigns)}
+        """
+      {:ok, val} -> val
+    end
   end
 
   defp unwrap({:safe, value}), do: value

--- a/test/phoenix_html/engine_test.exs
+++ b/test/phoenix_html/engine_test.exs
@@ -14,7 +14,7 @@ defmodule Phoenix.HTML.EngineTest do
   end
 
   test "raises KeyError for missing assigns" do
-    assert_raise ArgumentError, ~r/assign @foo not available in eex template assigns: \[:bar\]/, fn ->
+    assert_raise ArgumentError, ~r/assign @foo not available in eex template. Available assigns: \[:bar\]/, fn ->
       eval(@template, %{bar: "baz"})
     end
   end

--- a/test/phoenix_html/engine_test.exs
+++ b/test/phoenix_html/engine_test.exs
@@ -1,21 +1,28 @@
 defmodule Phoenix.HTML.EngineTest do
   use ExUnit.Case, async: true
 
-  test "evaluates expressions with buffers" do
-    string = """
-    <%= 123 %>
-    <% if true do %>
-      <%= 456 %>
-    <% end %>
-    <%= 789 %>
-    """
+  @template """
+  <%= 123 %>
+  <%= if @foo do %>
+    <%= 456 %>
+  <% end %>
+  <%= 789 %>
+  """
 
-    assert eval(string) == "123\n\n789\n"
+  test "evaluates expressions with buffers" do
+    assert eval(@template, %{foo: true}) == "123\n\n  456\n\n789\n"
   end
 
-  defp eval(string) do
+  test "raises KeyError for missing assigns" do
+    assert_raise KeyError, "key :foo not found in: %{}", fn ->
+      eval(@template, %{})
+    end
+  end
+
+  defp eval(string, assigns) do
     {:safe, io} =
-      EEx.eval_string(string, [], file: __ENV__.file, engine: Phoenix.HTML.Engine)
+      EEx.eval_string(string, [assigns: assigns],
+                      file: __ENV__.file, engine: Phoenix.HTML.Engine)
     IO.iodata_to_binary(io)
   end
 end

--- a/test/phoenix_html/engine_test.exs
+++ b/test/phoenix_html/engine_test.exs
@@ -14,8 +14,8 @@ defmodule Phoenix.HTML.EngineTest do
   end
 
   test "raises KeyError for missing assigns" do
-    assert_raise KeyError, "key :foo not found in: %{}", fn ->
-      eval(@template, %{})
+    assert_raise ArgumentError, ~r/assign @foo not available in eex template assigns: \[:bar\]/, fn ->
+      eval(@template, %{bar: "baz"})
     end
   end
 


### PR DESCRIPTION
ref: https://github.com/phoenixframework/phoenix/issues/879

@josevalim I expected this to be more work. I am post walking the body and rewriting `Dict.get(var!(assigns), var)` to `Dict.fetch!(var!(assigns), var)`. Do we need anything more? Are there edgecases I'm missing? Should we raise our own more helpful error?