### PR TITLE
Clearer error message when 2nd arg to link/2 is not a keyword list

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -45,23 +45,24 @@ defmodule Phoenix.HTML.Link do
   end
 
   def link(text, opts) do
-    {to, opts} = Keyword.pop(opts, :to)
-  rescue
-    _ -> raise ArgumentError, "link/2 requires a keyword list as second argument"
-  else
-    {nil, _opts} ->
-      raise ArgumentError, "option :to is required in link/2"
-    {to, opts}   ->
-      {method, opts} = Keyword.pop(opts, :method, :get)
+    cond do
+      not match?([{_key, _value}|_opts], opts) ->
+        raise ArgumentError, "link/2 requires a keyword list as second argument"
+      Keyword.get(opts, :to) ->
+        {to, opts} = Keyword.pop(opts, :to)
+        {method, opts} = Keyword.pop(opts, :method, :get)
 
-      if method == :get do
-        content_tag(:a, text, [href: to] ++ opts)
-      else
-        {form, opts} = form_options(opts, method, "link")
-        form_tag(to, form) do
-          content_tag(:a, text, [href: "#", onclick: "this.parentNode.submit(); return false;"] ++ opts)
+        if method == :get do
+          content_tag(:a, text, [href: to] ++ opts)
+        else
+          {form, opts} = form_options(opts, method, "link")
+          form_tag(to, form) do
+            content_tag(:a, text, [href: "#", onclick: "this.parentNode.submit(); return false;"] ++ opts)
+          end
         end
-      end
+      true ->
+        raise ArgumentError, "option :to is required in link/2"
+    end
   end
 
   @doc false

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -47,7 +47,7 @@ defmodule Phoenix.HTML.Link do
   def link(text, opts) do
     {to, opts} = Keyword.pop(opts, :to)
   rescue
-    _ -> raise ArgumentError, "option :to is required in link/2"
+    _ -> raise ArgumentError, "link/2 requires a keyword list as second argument"
   else
     {nil, _opts} ->
       raise ArgumentError, "option :to is required in link/2"
@@ -71,7 +71,7 @@ defmodule Phoenix.HTML.Link do
     {contents, opts} = Keyword.pop(opts, :do)
 
     unless contents do
-      raise ArgumentError, "link/2 requires a text as first agument or contents in the :do block"
+      raise ArgumentError, "link/2 requires a text as first argument or contents in the :do block"
     end
 
     link(contents, opts)

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -46,20 +46,22 @@ defmodule Phoenix.HTML.Link do
 
   def link(text, opts) do
     {to, opts} = Keyword.pop(opts, :to)
-    {method, opts} = Keyword.pop(opts, :method, :get)
-
-    unless to do
+  rescue
+    _ -> raise ArgumentError, "option :to is required in link/2"
+  else
+    {nil, _opts} ->
       raise ArgumentError, "option :to is required in link/2"
-    end
+    {to, opts}   ->
+      {method, opts} = Keyword.pop(opts, :method, :get)
 
-    if method == :get do
-      content_tag(:a, text, [href: to] ++ opts)
-    else
-      {form, opts} = form_options(opts, method, "link")
-      form_tag(to, form) do
-        content_tag(:a, text, [href: "#", onclick: "this.parentNode.submit(); return false;"] ++ opts)
+      if method == :get do
+        content_tag(:a, text, [href: to] ++ opts)
+      else
+        {form, opts} = form_options(opts, method, "link")
+        form_tag(to, form) do
+          content_tag(:a, text, [href: "#", onclick: "this.parentNode.submit(); return false;"] ++ opts)
+        end
       end
-    end
   end
 
   @doc false

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -36,7 +36,7 @@ defmodule Phoenix.HTML.LinkTest do
   test "link with invalid args" do
     msg = "option :to is required in link/2"
     assert_raise ArgumentError, msg, fn ->
-      link("foo", [])
+      link("foo", [bar: "baz"])
     end
 
     msg = "link/2 requires a keyword list as second argument"

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -31,21 +31,22 @@ defmodule Phoenix.HTML.LinkTest do
     end)
 
     assert safe_to_string(link(to: "/hello", do: "world")) == ~s[<a href="/hello">world</a>]
-
-    msg = "link/2 requires a text as first agument or contents in the :do block"
-    assert_raise ArgumentError, msg, fn ->
-      link(to: "/hello-world")
-    end
   end
 
   test "link with invalid args" do
     msg = "option :to is required in link/2"
-
     assert_raise ArgumentError, msg, fn ->
       link("foo", [])
     end
+
+    msg = "link/2 requires a keyword list as second argument"
     assert_raise ArgumentError, msg, fn ->
       link("foo", "/login")
+    end
+
+    msg = "link/2 requires a text as first argument or contents in the :do block"
+    assert_raise ArgumentError, msg, fn ->
+      link(to: "/hello-world")
     end
   end
 

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -38,6 +38,17 @@ defmodule Phoenix.HTML.LinkTest do
     end
   end
 
+  test "link with invalid args" do
+    msg = "option :to is required in link/2"
+
+    assert_raise ArgumentError, msg, fn ->
+      link("foo", [])
+    end
+    assert_raise ArgumentError, msg, fn ->
+      link("foo", "/login")
+    end
+  end
+
   test "button with post (default)" do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 


### PR DESCRIPTION
When calling link/2 like `link("Logout", "/logout")`, you get the ff error `no function clause matching in Keyword.pop/3`. This PR just raises a clearer error message when the 2nd arg to `link/2` is not a keyword list.