### PR TITLE
Make sure nil params submitted to the form are not ignored in favour of their original values

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -802,7 +802,7 @@ defmodule Phoenix.HTML.Form do
   ## Helpers
 
   defp value_from(%{model: model, params: params}, field),
-    do: Map.get(params, Atom.to_string(field)) || Map.get(model, field)
+    do: Map.get(params, Atom.to_string(field), Map.get(model, field))
   defp value_from(name, _field) when is_atom(name),
     do: nil
 

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -7,6 +7,7 @@ defmodule Phoenix.HTML.FormTest do
 
   @conn Plug.Test.conn(:get, "/foo", %{"search" => %{
     "key" => "value",
+    "alt_key" => nil,
     "datetime" => %{"year" => "2020", "month" => "4", "day" => "17",
                     "hour" => "2",   "min" => "11", "sec" => "13"}
   }})
@@ -71,6 +72,9 @@ defmodule Phoenix.HTML.FormTest do
   test "text_input/3 with form" do
     assert safe_form(&text_input(&1, :key)) ==
            ~s(<input id="search_key" name="search[key]" type="text" value="value">)
+
+    assert safe_form(&text_input(&1, :alt_key)) ==
+           ~s(<input id="search_alt_key" name="search[alt_key]" type="text">)
 
     assert safe_form(&text_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
            ~s(<input id="key" name="search[key][]" type="text" value="foo">)


### PR DESCRIPTION
Fixes #11

`Map.get/3` has a third option of a default if the key isn't found in `params`, which seems like exactly what we want.

edit: actually I think the fix is right, but the test is wrong. Looking into it more.