### PR TITLE
Allow default text content on labels to be inferred from field

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -784,6 +784,7 @@ defmodule Phoenix.HTML.Form do
   All given options are forwarded to the underlying tag.
   A default value is provided for `for` attribute but can
   be overriden if you pass a value to the `for` option.
+  Text content would be inferred from `field` if not specified.
 
   ## Examples
 
@@ -793,10 +794,23 @@ defmodule Phoenix.HTML.Form do
 
       label(:user, :email, "Email")
       #=> <label for="user_email">Email</label>
+
+      label(:user, :email)
+      #=> <label for="user_email">Email</label>
+
+      label(:user, :email, class="control-label")
+      #=> <label for="user_email" class="control-label">Email</label>
   """
-  def label(form, field, text, opts \\ []) do
+  def label(form, field, text_or_opts \\ nil, opts \\ [])
+  def label(form, field, text_or_opts, opts) when is_nil(text_or_opts) do
+    label(form, field, humanize(field), opts)
+  end
+  def label(form, field, text_or_opts, _opts) when is_list(text_or_opts) do
+    label(form, field, humanize(field), text_or_opts)
+  end
+  def label(form, field, text_or_opts, opts) do
     opts = Keyword.put_new(opts, :for, id_from(form, field))
-    content_tag(:label, text, opts)
+    content_tag(:label, text_or_opts, opts)
   end
 
   ## Helpers

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -615,4 +615,20 @@ defmodule Phoenix.HTML.FormTest do
     assert safe_form(&label(&1, :key, "Search", for: "test_key")) ==
           ~s(<label for="test_key">Search</label>)
   end
+
+  test "label/4 with default value" do
+    assert safe_to_string(label(:search, :key)) ==
+          ~s(<label for="search_key">Key</label>)
+
+    assert safe_to_string(label(:search, :key, for: "test_key")) ==
+          ~s(<label for="test_key">Key</label>)
+  end
+
+  test "label/4 with form and default value" do
+    assert safe_form(&label(&1, :key)) ==
+          ~s(<label for="search_key">Key</label>)
+
+    assert safe_form(&label(&1, :key, for: "test_key")) ==
+          ~s(<label for="test_key">Key</label>)
+  end
 end


### PR DESCRIPTION
I believe is pretty common to have label text content the same as the field name.
Example, I keep doing this a lot:
```erb
<%= text_input f, :first_name,  "First name" %>
<%= text_input f, :middle_name, "Middle name" %>
<%= text_input f, :last_name,   "Last name" %>
<%= text_input f, :gender,      "Gender" %>
```

So I thought it was a good idea to improve the helper so the label text content can be inferred from the actual field.