### PR TITLE
fix option in inputs_for doc

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -246,7 +246,7 @@ defmodule Phoenix.HTML.Form do
       applies if the field value is a list and no parameters were
       sent through the form.
 
-    * `:prepend` - the values to append when rendering. This only
+    * `:append` - the values to append when rendering. This only
       applies if the field value is a list and no parameters were
       sent through the form.
   """


### PR DESCRIPTION
Does this option mean `append` ? Because `prepend` already described just above line.