### PR TITLE
Add an error css class to input fields

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -413,14 +413,35 @@ defmodule Phoenix.HTML.Form do
   def range_input(form, field, opts \\ []) do
     generic_input(:range, form, field, opts)
   end
+   
+  defp maybe_put_error(opts, %Form{errors: errors}, field) do
+    classes = Keyword.get(opts, :class, "")
+
+    error_message = case List.keyfind(errors, field, 0) do
+      {field, message} -> "field_with_errors"
+      _not_found -> ""
+    end
+
+    class_with_maybe_error = "#{classes} #{error_message}" |> String.strip
+
+    opts
+    |> Keyword.put(:class, class_with_maybe_error)
+    |> Keyword.delete(:class, nil)
+    |> Keyword.delete(:class, "")
+  end
+  defp maybe_put_error(opts, form, field) do
+    opts
+  end
 
   defp generic_input(type, form, field, opts) when is_atom(field) and is_list(opts) do
     opts =
       opts
+      |> maybe_put_error(form, field)
       |> Keyword.put_new(:type, type)
       |> Keyword.put_new(:id, id_from(form, field))
       |> Keyword.put_new(:name, name_from(form, field))
       |> Keyword.put_new(:value, value_from(form, field))
+
     tag(:input, opts)
   end
 

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -47,6 +47,43 @@ defmodule Phoenix.HTML.FormTest do
     assert form =~ ~s(<input name="_utf8" type="hidden" value="✓">)
   end
 
+  test "form_for/4 with changeset and an error on :name" do
+    name = "name"
+
+    form = %Phoenix.HTML.Form{
+      id: name,
+      name: name,
+      errors: [name: "Error"],
+      params: %{},
+      options: %{}
+    }
+
+    assert safe_to_string(text_input(form, :name, class: "username")) == 
+      "<input class=\"username field_with_errors\" id=\"name_name\" name=\"name[name]\" type=\"text\">"
+
+    assert safe_to_string(text_input(form, :name)) == 
+      "<input class=\"field_with_errors\" id=\"name_name\" name=\"name[name]\" type=\"text\">"
+  end
+
+
+  test "form_for/4 with changeset and no errors" do
+    name = "name"
+
+    form = %Phoenix.HTML.Form{
+      id: name,
+      name: name,
+      errors: [],
+      params: %{},
+      options: %{}
+    }
+
+    assert safe_to_string(text_input(form, :name, class: "username")) == 
+      "<input class=\"username\" id=\"name_name\" name=\"name[name]\" type=\"text\">"
+
+    assert safe_to_string(text_input(form, :name)) == 
+      "<input id=\"name_name\" name=\"name[name]\" type=\"text\">"
+  end  
+
   test "form_for/4 with custom options" do
     form = safe_to_string form_for(conn(), "/", [name: :search, method: :put, multipart: true], fn f ->
       refute f.options[:name]


### PR DESCRIPTION
This commit adds the "field_with_errors" css class
to input fields if there is a matching error on form.errors.
This makes it easier to style the errors on a changeset form
(ecto…) without adding this manually for every input in the form.

Hi!

I'm not sure if this is a fit for the phoenix_html project or if this has been discussed already.
Also note that I'm just starting to get into Elixir so code might not be idiomatic Elixir.

