### PR TITLE
Nested & attr-less content_tag throws exception

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -48,8 +48,12 @@ defmodule Phoenix.HTML.Tag do
       ...> end
       {:safe, ["<p class=\"test\">", "Hello", "</p>"]}
   """
-  def content_tag(name, content) when is_atom(name) do
+  def content_tag(name, content) when is_atom(name) and not is_list(content) do
     content_tag(name, content, [])
+  end
+
+  def content_tag(name, [do: block]) when is_atom(name) do
+    content_tag(name, block, [])
   end
 
   def content_tag(name, attrs, [do: block]) when is_atom(name) and is_list(attrs) do

--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -48,12 +48,11 @@ defmodule Phoenix.HTML.Tag do
       ...> end
       {:safe, ["<p class=\"test\">", "Hello", "</p>"]}
   """
-  def content_tag(name, content) when is_atom(name) and not is_list(content) do
-    content_tag(name, content, [])
-  end
-
   def content_tag(name, [do: block]) when is_atom(name) do
     content_tag(name, block, [])
+  end
+  def content_tag(name, content) when is_atom(name) do
+    content_tag(name, content, [])
   end
 
   def content_tag(name, attrs, [do: block]) when is_atom(name) and is_list(attrs) do

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -72,6 +72,16 @@ defmodule Phoenix.HTML.TagTest do
     assert safe_to_string(content) ==
            ~s(<form action="/users" data-remote="true">) <>
            ~s(<input name="user[name]"></form>)
+
+    assert content_tag(:p, do: "Hello") ==
+            {:safe, ["<p>", "Hello", "</p>"]}
+
+    content = content_tag :ul do
+                content_tag :li do
+                  "Hello"
+                end
+              end
+    assert content == {:safe, ["<ul>", ["<li>", "Hello", "</li>"], "</ul>"]}
   end
 
   test "form_tag for get" do

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -82,6 +82,8 @@ defmodule Phoenix.HTML.TagTest do
                 end
               end
     assert content == {:safe, ["<ul>", ["<li>", "Hello", "</li>"], "</ul>"]}
+
+    assert content_tag(:p, ["hello", ?\s, "world"]) == {:safe, ["<p>", ["hello", 32, "world"], "</p>"]}
   end
 
   test "form_tag for get" do


### PR DESCRIPTION
Found this while trying to build and unordered list here: https://github.com/mgwidmann/scrivener_html/blob/master/lib/scrivener/html.ex#L112

