### PR TITLE
link("here", to: nil) says :to was not provided

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -72,7 +72,7 @@ defmodule Phoenix.HTML.Link do
     {method, opts} = Keyword.pop(opts, :method, :get)
 
     unless to do
-      raise ArgumentError, "option :to is required in link/2"
+      raise ArgumentError, "expected non-nil value for :to in link/2, got: #{inspect to}"
     end
 
     if method == :get do

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -34,7 +34,7 @@ defmodule Phoenix.HTML.LinkTest do
   end
 
   test "link with invalid args" do
-    msg = "option :to is required in link/2"
+    msg = "expected non-nil value for :to in link/2, got: nil"
     assert_raise ArgumentError, msg, fn ->
       link("foo", [bar: "baz"])
     end


### PR DESCRIPTION
Its very confusing when the `:to` option was provided but it says that it was not provided (but that actually the code cannot tell that the value was `nil`)

This improves the error message and returns the options to the user so that they can decipher for themselves what went wrong. In the case where nil was provided, it will be more obvious.