### PR TITLE
Adds escape_javascript method

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -62,7 +62,7 @@ defmodule Phoenix.HTML do
 
   @doc """
   Provides `~e` sigil with HTML safe EEx syntax inside source files.
-  
+
   Raises on attempts to interpolate with `#{}`, so `~E` should be preferred.
 
       iex> ~e"\""
@@ -77,7 +77,7 @@ defmodule Phoenix.HTML do
 
   @doc """
   Provides `~E` sigil with HTML safe EEx syntax inside source files.
-  
+
   Does not raise on attempts to interpolate with `#{}`, but rather shows those
   characters literally, so it should be preferred over `~e`.
 
@@ -157,4 +157,30 @@ defmodule Phoenix.HTML do
   def safe_to_string({:safe, iodata}) do
     IO.iodata_to_binary(iodata)
   end
+
+  @escape_javascript_map %{
+    "\\"    => "\\\\",
+    "</"    => "<\/",
+    "\r\n"  => "\n",
+    "\r"    => "\n",
+    "\""    => "\\\"",
+    "'"     => "\\'"
+  }
+
+  @doc """
+  Escapes double and single quotes, double backslashes, carriage returns and other
+
+  This method is extremely helpful in JavaScript responses when there is a need
+  to escape html rendered from other templates, like in the following:
+
+  $("#container").append("<%= escape_javascript(render("post.html", post: @post)) %>");
+
+  """
+  @spec escape_javascript(safe) :: String.t
+  def escape_javascript(safe) do
+    Regex.replace(~r/(\\|<\/|\r\n|[\n\r"'])/u, safe_to_string(safe), fn match ->
+      @escape_javascript_map[match]
+    end)
+  end
+
 end

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -31,4 +31,14 @@ defmodule Phoenix.HTMLTest do
     assert Safe.to_iodata(1.0) == "1.0"
     assert Safe.to_iodata({:safe, "<foo>"}) == "<foo>"
   end
+
+  test "Phoenix.HTML.escape_javascript/1" do
+    assert escape_javascript({:safe, ""}) == ""
+    assert escape_javascript({:safe, "\\Double backslash"}) == "\\\\Double backslash"
+    assert escape_javascript({:safe, "</closing tag>"}) == "<\/closing tag>"
+    assert escape_javascript({:safe, "Windows line break \r\n"}) == "Windows line break \n"
+    assert escape_javascript({:safe, "Carriage return \r"}) == "Carriage return \n"
+    assert escape_javascript({:safe, "\"Double quote\""}) == "\\\"Double quote\\\""
+    assert escape_javascript({:safe, "'Single quote'"}) == "\\'Single quote\\'"
+  end
 end

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -33,12 +33,9 @@ defmodule Phoenix.HTMLTest do
   end
 
   test "Phoenix.HTML.escape_javascript/1" do
-    assert escape_javascript({:safe, ""}) == ""
-    assert escape_javascript({:safe, "\\Double backslash"}) == "\\\\Double backslash"
-    assert escape_javascript({:safe, "</closing tag>"}) == "<\/closing tag>"
-    assert escape_javascript({:safe, "Windows line break \r\n"}) == "Windows line break \n"
-    assert escape_javascript({:safe, "Carriage return \r"}) == "Carriage return \n"
-    assert escape_javascript({:safe, "\"Double quote\""}) == "\\\"Double quote\\\""
-    assert escape_javascript({:safe, "'Single quote'"}) == "\\'Single quote\\'"
+    assert escape_for_javascript("") == ""
+    assert escape_for_javascript("\\Double backslash") == "\\\\Double backslash"
+    assert escape_for_javascript("\"Double quote\"") == "\\\"Double quote\\\""
+    assert escape_for_javascript("'Single quote'") == "\\'Single quote\\'"
   end
 end


### PR DESCRIPTION
The regex for the method is taken from RoR's `javascript_method` but with 2 elements removed from it, specifically `\342\200\250` and `\342\200\251` because I am simply not sure what those are for and I can't implement them anyway so it's open for an enhancement.

Also the list of matches is implemented as a module attribute, which may be wrong, and if it is, then I guess it won't be problematic to make it a private method or whatever.

If this PR is just completely wrong then I hope that this method will still be implemented in one form or another but by somebody more experienced