### PR TITLE
Should preserve the field value in multiple_select

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -751,7 +751,7 @@ defmodule Phoenix.HTML.Form do
   """
   def multiple_select(form, field, values, opts \\ []) do
     {default, opts}  = Keyword.pop(opts, :default, [])
-    {multiple, opts} = Keyword.pop(opts, :value, default)
+    {multiple, opts} = Keyword.pop(opts, :value, value_from(form, field) || default)
 
     opts =
       opts

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -493,6 +493,12 @@ defmodule Phoenix.HTML.FormTest do
            ~s(<option selected="selected" value="novalue">novalue</option>) <>
            ~s(</select>)
 
+    assert safe_form(&multiple_select(put_in(&1.params["key"], ["3"]), :key, [{"foo", 1}, {"bar", 2}, {"goo", 3}], default: [2])) ==
+          ~s(<select id="search_key" multiple="" name="search[key][]">) <>
+          ~s(<option value="1">foo</option>) <>
+          ~s(<option value="2">bar</option>) <>
+          ~s(<option selected="selected" value="3">goo</option>) <>
+          ~s(</select>)
   end
 
   # date_select/4


### PR DESCRIPTION
This allows the multiple_select/4 function to preserve the values that were submitted to the model.

This resolves issue #32 