### PR TITLE
Try to hint why an expected view assign is missing

### DIFF
--- a/lib/phoenix_html/engine.ex
+++ b/lib/phoenix_html/engine.ex
@@ -83,7 +83,13 @@ defmodule Phoenix.HTML.Engine do
     case Dict.fetch(assigns, key) do
       :error ->
         raise ArgumentError, message: """
-        assign @#{key} not available in eex template. Available assigns: #{inspect Dict.keys(assigns)}
+        assign @#{key} not available in eex template.
+
+        Please make sure all proper assigns have been set. If this
+        is a child template, ensure assigns are given explicitly by
+        the parent template as they are not automatically forwarded.
+
+        Available assigns: #{inspect Dict.keys(assigns)}
         """
       {:ok, val} -> val
     end

--- a/test/phoenix_html/engine_test.exs
+++ b/test/phoenix_html/engine_test.exs
@@ -14,7 +14,7 @@ defmodule Phoenix.HTML.EngineTest do
   end
 
   test "raises KeyError for missing assigns" do
-    assert_raise ArgumentError, ~r/assign @foo not available in eex template. Available assigns: \[:bar\]/, fn ->
+    assert_raise ArgumentError, ~r/assign @foo not available in eex template.*Available assigns: \[:bar\]/s, fn ->
       eval(@template, %{bar: "baz"})
     end
   end


### PR DESCRIPTION
This is an alternative approach to my previous pull request, phoenixframework/phoenix#1342.  I'm submitting this because I found the framework behavior surprising and it took me a while to figure it out. I understand the motivation for not accepting my previous PR, so I'm hopeful that this log message will save time for others who encounter a similar issue.

I'm not 100% confident in the terminology I chose (parent vs. child view template), so please feel free to offer alternative wording suggestions.