### PR TITLE
Add Phoenix.HTML.Format.text_to_html/2

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -12,6 +12,8 @@ defmodule Phoenix.HTML do
 
     * `Phoenix.HTML.Link` - functions for generating links and urls;
 
+    * `Phoenix.HTML.Format` - functions for formatting text;
+
   ## HTML Safe
 
   One of the main responsibilities of this module is to

--- a/lib/phoenix_html/format.ex
+++ b/lib/phoenix_html/format.ex
@@ -1,0 +1,63 @@
+defmodule Phoenix.HTML.Format do
+  @moduledoc """
+  Helpers related to formatting text.
+  """
+
+  @doc ~S"""
+  Returns text transformed into HTML using simple formatting rules.
+
+  Two or more consecutive newlines `\n\n` are considered as a paragraph
+  and text between them is wrapped in `<p>` tags.
+  One newline `\n` is considered as a linebreak and a `<br>` tag is inserted.
+
+  ## Examples
+
+      iex> text_to_html("Hello\n\nWorld") |> safe_to_string
+      "<p>Hello</p>\n<p>World</p>\n"
+
+      iex> text_to_html("Hello\nWorld") |> safe_to_string
+      "<p>Hello<br>\nWorld</p>\n"
+
+      iex> opts = [wrapper_tag: :div, attributes: [class: "p"]]
+      ...> text_to_html("Hello\n\nWorld", opts) |> safe_to_string
+      "<div class=\"p\">Hello</div>\n<div class=\"p\">World</div>\n"
+
+  ## Options
+
+    * `:escape` - if `false` does not html escape input (default: `true`)
+    * `:wrapper_tag` - tag to wrap each parapgraph (default: `:p`)
+    * `:attributes` - html attributes of the wrapper tag (default: `[]`)
+
+  """
+  @spec text_to_html(Phoenix.HTML.unsafe, Keyword.t) :: Phoenix.HTML.safe
+  def text_to_html(string, opts \\ []) do
+    escape?     = Keyword.get(opts, :escape, true)
+    wrapper_tag = Keyword.get(opts, :wrapper_tag, :p)
+    attributes  = Keyword.get(opts, :attributes, [])
+
+    string
+    |> maybe_html_escape(escape?)
+    |> String.split("\n\n", trim: true)
+    |> Enum.filter_map(&not_blank?/1, &wrap_paragraph(&1, wrapper_tag, attributes))
+    |> Phoenix.HTML.html_escape
+  end
+
+  defp maybe_html_escape(string, true),  do: Plug.HTML.html_escape(string)
+  defp maybe_html_escape(string, false), do: string
+
+  defp not_blank?(" " <> rest),  do: not_blank?(rest)
+  defp not_blank?("\n" <> rest), do: not_blank?(rest)
+  defp not_blank?(""),           do: false
+  defp not_blank?(_),            do: true
+
+  defp wrap_paragraph(text, tag, attributes) do
+    [Phoenix.HTML.Tag.content_tag(tag, insert_brs(text), attributes), ?\n]
+  end
+
+  defp insert_brs(text) do
+    text
+    |> String.split("\n", trim: true)
+    |> Enum.map(&Phoenix.HTML.raw/1)
+    |> Enum.intersperse([Phoenix.HTML.Tag.tag(:br), ?\n])
+  end
+end

--- a/test/phoenix_html/format_test.exs
+++ b/test/phoenix_html/format_test.exs
@@ -1,0 +1,70 @@
+defmodule Phoenix.HTML.FormatTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.HTML.Format
+  import Phoenix.HTML
+
+  doctest Phoenix.HTML.Format
+
+  test "wraps paragraphs" do
+    formatted =
+      format("""
+      Hello,
+
+      Please come see me.
+
+      Regards,
+      The boss.
+      """)
+
+    assert formatted == """
+    <p>Hello,</p>
+    <p>Please come see me.</p>
+    <p>Regards,<br>
+    The boss.</p>
+    """
+  end
+
+  test "escapes html" do
+    formatted =
+      format("""
+      <script></script>
+      """)
+
+    assert formatted == """
+    <p>&lt;script&gt;&lt;/script&gt;</p>
+    """
+  end
+
+  test "skips escaping html" do
+    formatted =
+      format("""
+      <script></script>
+      """, escape: false)
+
+    assert formatted == """
+    <p><script></script></p>
+    """
+  end
+
+  test "adds brs" do
+    formatted =
+      format("""
+      Hello,
+      This is dog,
+      How can I help you?
+
+
+      """)
+
+    assert formatted == """
+    <p>Hello,<br>
+    This is dog,<br>
+    How can I help you?</p>
+    """
+  end
+
+  defp format(text, opts \\ []) do
+    text |> text_to_html(opts) |> safe_to_string
+  end
+end


### PR DESCRIPTION
Because I recently needed this functionality I implemented it in a package [simple_format](https://github.com/michalmuskala/simple_format), but @josevalim advised adding it directly to `Phoenix.HTML`. So here it is :smiley: 