### PR TITLE
Fix for cast example in Phoenix.HTML.Form docs

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.HTML.Form do
   where `User.changeset/2` is defined as follows:
 
       def changeset(user, params \\ :empty) do
-        cast(user, params)
+        cast(user, params, ~w(name age), ~w())
       end
 
   Now a `@changeset` assign is available in views which we


### PR DESCRIPTION
In the section of "With model data" for the `Phoenix.HTML.Form` docs, in the definition of the `User.changeset/2` function, the example calls a `cast/2` function but I think that the intention here is to call the `Ecto.Changeset.cast/4` function. Is that is the case this change could help.