### PR TITLE
Documentation changes for Phoenix 1.1

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -95,7 +95,7 @@ defmodule Phoenix.HTML.Form do
   Imagine the models:
 
       defmodule User do
-        use Ecto.Model
+        use Ecto.Schema
 
         schema "users" do
           field :name
@@ -104,7 +104,7 @@ defmodule Phoenix.HTML.Form do
       end
 
       defmodule Permalink do
-        use Ecto.Model
+        use Ecto.Schema
 
         embedded_schema do
           field :url


### PR DESCRIPTION
From this changelog:
https://gist.github.com/chrismccord/557ef22e2a03a7992624

`Ecto.Model` was changed to `Ecto.Schema`

This commit changes that usage in the documentation for
form.ex.