### PR TITLE
Add support for tags with lists as attribute values

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -117,12 +117,20 @@ defmodule Phoenix.HTML.Tag do
   defp build_attrs(tag, [{_, nil}|t], acc) do
     build_attrs(tag, t, acc)
   end
+  defp build_attrs(tag, [{_, []}|t], acc) do
+    build_attrs(tag, t, acc)
+  end
+  defp build_attrs(tag, [{k, v}|t], acc) when is_list(v) do
+    build_attrs(tag, t, [{dasherize(k), flatten(v)}|acc])
+  end
   defp build_attrs(tag, [{k, v}|t], acc) do
     build_attrs(tag, t, [{dasherize(k), v}|acc])
   end
 
   defp dasherize(value) when is_atom(value),   do: dasherize(Atom.to_string(value))
   defp dasherize(value) when is_binary(value), do: String.replace(value, "_", "-")
+
+  defp flatten(value) when is_list(value), do: Enum.join(value, ", ")
 
   @doc ~S"""
   Generates a form tag.

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -33,6 +33,11 @@ defmodule Phoenix.HTML.TagTest do
     assert tag(:input, data: [toggle: [target: "#parent", attr: "blah"]]) ==
            {:safe, ~s(<input data-toggle-attr="blah" data-toggle-target="#parent">)}
 
+    assert tag(:input, value: []) == {:safe, ~s(<input>)}
+
+    list_val = ["foo", "bar"]
+    assert tag(:input, value: list_val) == {:safe, ~s(<input value="foo, bar">)}
+
     assert tag(:audio, autoplay: true) ==
            {:safe, ~s(<audio autoplay="autoplay">)}
 


### PR DESCRIPTION
Handy when you have arrays in an ecto model for example.

Not sure if this is the right place to do this or if it's even desirable.