### PR TITLE
More helpful error when missing translate_error

### DIFF
--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -70,4 +70,9 @@ end
 
 defimpl Phoenix.HTML.Safe, for: Tuple do
   def to_iodata({:safe, data}), do: data
+  def to_iodata(value) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: value
+  end
 end

--- a/test/phoenix_html/safe_test.exs
+++ b/test/phoenix_html/safe_test.exs
@@ -22,4 +22,10 @@ defmodule Phoenix.HTML.SafeTest do
     assert Safe.to_iodata(1.0) == "1.0"
     assert Safe.to_iodata({:safe, "<foo>"}) == "<foo>"
   end
+
+  test "Phoenix.HTML.Safe given an invalid tuple" do
+    assert_raise Protocol.UndefinedError, fn ->
+      Safe.to_iodata({"needs %{count}", [count: 123]})
+    end
+  end
 end


### PR DESCRIPTION
Since this is very specific, I don't have great hopes that it'll be merged as-is.

But I've seen people on Slack that were bit by this, three times in the last few days, and I haven't even been looking. So I'm thinking a small, simple fix that we can remove by Phoenix 2 or earlier can be a cheap way of avoiding some upgrade pain.