### PR TITLE
Test to prove input_for does not work with file_input

### DIFF
--- a/test/phoenix_html/inputs_for_test.exs
+++ b/test/phoenix_html/inputs_for_test.exs
@@ -8,7 +8,7 @@ defmodule Phoenix.HTML.InputsForTest do
   A function that executes `inputs_for/4` and
   extracts its inner contents for assertion.
   """
-  def safe_inputs_for(field, opts \\ [multipart: false], fun) do
+  def safe_inputs_for(field, opts \\ [], fun) do
     mark = "--PLACEHOLDER--"
     {multipart, opts} = Keyword.pop(opts, :multipart, false)
     conn =


### PR DESCRIPTION
A test to prove file_input does not work together with inputs_for as mention in Bug #70.

`safe_inputs_for` is a bit problematic as the opts are put in inputs_for and I required an option for form_for. I hope to find time to be able to fix the problem it self.