### PR TITLE
Fix form tag example code

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -211,7 +211,7 @@ defmodule Phoenix.HTML.Tag do
       form_tag("/hello", method: "get") do
         "Hello"
       end
-      <form action="/hello" method="post">...Hello...</form>
+      <form action="/hello" method="get">...Hello...</form>
 
   """
   def form_tag(action, options, do: block) do


### PR DESCRIPTION
Example usage of `form_tag` had "get" in arguments, but "post" in output.