### PR TITLE
Do not add a class to buttons by default

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -112,7 +112,7 @@ defmodule Phoenix.HTML.Link do
   ## Examples
 
       button("hello", to: "/world")
-      #=> <form action="/world" class="button" method="post">
+      #=> <form action="/world" method="post">
             <input name="_csrf_token" value=""><input type="submit" value="hello">
           </form>
 
@@ -128,7 +128,7 @@ defmodule Phoenix.HTML.Link do
     * `:method` - the method to use with the button. Defaults to :post.
 
     * `:form` - the options for the form. Defaults to
-      `[class: "button", enforce_utf8: false]`
+      `[enforce_utf8: false]`
 
   All other options are forwarded to the underlying button input.
   """
@@ -136,7 +136,7 @@ defmodule Phoenix.HTML.Link do
     {to, opts} = Keyword.pop(opts, :to)
     {method, opts} = Keyword.pop(opts, :method, :post)
 
-    {form, opts} = form_options(opts, method, "button")
+    {form, opts} = form_options(opts, method)
 
     opts =
       opts
@@ -152,7 +152,7 @@ defmodule Phoenix.HTML.Link do
     end
   end
 
-  defp form_options(opts, method, class) do
+  defp form_options(opts, method, class \\ nil) do
     {form, opts} = Keyword.pop(opts, :form, [])
 
     form =

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -54,7 +54,7 @@ defmodule Phoenix.HTML.LinkTest do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(button("hello", to: "/world")) ==
-           ~s[<form action="/world" class="button" method="post">] <>
+           ~s[<form action="/world" method="post">] <>
            ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
            ~s[<input type="submit" value="hello">] <>
            ~s[</form>]
@@ -62,7 +62,7 @@ defmodule Phoenix.HTML.LinkTest do
 
   test "button with get does not generate CSRF" do
     assert safe_to_string(button("hello", to: "/world", method: :get)) ==
-           ~s[<form action="/world" class="button" method="get">] <>
+           ~s[<form action="/world" method="get">] <>
            ~s[<input type="submit" value="hello">] <>
            ~s[</form>]
   end


### PR DESCRIPTION
It seems like an odd decision to add a class to any markup generated without the user opting into that decision. Happy to hear opinions on this decision but I thought I would get the ball rolling.