### PR TITLE
Added new form element generator for helper text

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1141,4 +1141,47 @@ defmodule Phoenix.HTML.Form do
   def field_name(name, field) when is_atom(name),
     do: "#{name}[#{field}]"
 
+  @doc """
+  Generates standard markup for field help text.
+
+  The form should either be a `Phoenix.HTML.Form` emitted
+  by `form_for` or an atom.
+
+  All given options are forwarded to the underlying tag.
+
+  ## Examples
+
+      help_text("Please provide your full name.")
+      #=> <small>Please provide your full name.</small>
+
+      help_text("Please provide your email.", class: "text-muted")
+      #=> <small class="text-muted">Please provide your email.</small>
+
+      help_text do
+        "Please provide your email."
+      end
+      #=> <small>Please provide your email.</small>
+
+      help_text class: "text-muted" do
+        "Please provide your email."
+      end
+      #=> <small class="text-muted">Please provide your email.</small>
+  """
+  def help_text(text) when is_binary(text) do
+    help_text(text, [])
+  end
+  def help_text([do: block]) do
+    help_text([], do: block)
+  end
+
+  @doc """
+  See `help_text/1`.
+  """
+  def help_text(text, opts) when is_binary(text) and is_list(opts) do
+    content_tag(:small, text, opts)
+  end
+  def help_text(opts, [do: block]) do
+    content_tag(:small, opts, do: block)
+  end
+
 end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -793,4 +793,23 @@ defmodule Phoenix.HTML.FormTest do
   test "field_name/2 with form" do
     assert safe_form(&field_name(&1, :key)) == "search[key]"
   end
+
+  ## help_text/1
+
+  test "help_text/1" do
+    assert safe_to_string(help_text("Search the whole site")) ==
+          ~s(<small>Search the whole site</small>)
+  end
+
+  ## help_text/2
+
+  test "help_text/2" do
+    assert safe_to_string(help_text("Search the whole site", [class: "text-muted"])) ==
+          ~s(<small class="text-muted">Search the whole site</small>)
+  end
+
+  test "help_text/2 with a block" do
+    assert safe_to_string(help_text([class: "text-muted"], do: "Search the whole site")) ==
+          ~s(<small class="text-muted">Search the whole site</small>)
+  end
 end


### PR DESCRIPTION
I was building out a Phoenix site recently, and coming from a CMS background noticed that on nearly every form element I found myself adding helper text boilerplate like:

`<small class="text-muted">A cron-formatted schedule string</small>`

What I really wanted was something that could generate the boilerplate for me:

`<%= help_text "A cron-formatted schedule string", class: "text-muted" %>`

This PR contains the proposed **help_text/2** functions.  Modeled after the **label/2** and **label/4** functions, it also introduces a do-block variant that would allow for code-based generation of the help text from form data.  I feel that along with all the other helper functions provided to generate consistent form markup, this would be a nice addition.

Thanks for looking!