### PR TITLE
Add Phoenix.HTML.Form backwords incompatible changes in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   * Use event delegation in `phoenix_html.js`
   * Drop IE8 support on `phoenix_html.js`
 
+* Backwards incompatible changes
+  * `:min`, `:sec` option in `Phoenix.HTML.Form` (`datetime_select/3` and `time_select/3`) are no longer supported. Use `:minute` or `:second` instead.
+
 ## v2.5.1 (2016-03-12)
 
 * Bug fixes


### PR DESCRIPTION
As of [this commit](https://github.com/phoenixframework/phoenix_html/commit/1c1ee243583f79eefbbb4655dbbd8e287eb21821), `:min`, `:sec` option in `Phoenix.HTML.Form.datetime_select/3` (or `Phoenix.HTML.Form.time_select/3`) are no longer supported. This change breaks code in older version. For example:

```elixir
<%= datetime_select form, :born_at, builder: fn b -> %>
  Date: <%= b.(:day, []) %> / <%= b.(:month, []) %> / <%= b.(:hour, []) %>
  Time: <%= b.(:hour, []) %> : <%= b.(:min, []) %>
<% end %>
```

Error output:

```
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in anonymous fn/2 in Phoenix.HTML.Form.datetime_builder/5
        (phoenix_html) lib/phoenix_html/form.ex:1002: anonymous fn(:min, []) in Phoenix.HTML.Form.datetime_builder/5
```