### PR TITLE
Fix submit links in phantomjs

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -8,7 +8,7 @@ function isLinkToSubmitParent(element) {
 }
 
 function didHandleSubmitLinkClick(element) {
-  while (element) {
+  while (element && element.getAttribute) {
     if (isLinkToSubmitParent(element)) {
       var message = element.getAttribute('data-confirm');
       if (message === null || confirm(message)) {

--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -1,8 +1,15 @@
 'use strict';
 
-function didHandleSubmitLinkClick(element){
-  while(element) {
-    if(element.matches && element.matches('a[data-submit=parent]')){
+function isLinkToSubmitParent(element) {
+  var isLinkTag = element.tagName === 'A';
+  var shouldSubmitParent = element.getAttribute('data-submit') === 'parent';
+
+  return isLinkTag && shouldSubmitParent;
+}
+
+function didHandleSubmitLinkClick(element) {
+  while (element) {
+    if (isLinkToSubmitParent(element)) {
       var message = element.getAttribute('data-confirm');
       if (message === null || confirm(message)) {
         element.parentNode.submit();
@@ -17,8 +24,9 @@ function didHandleSubmitLinkClick(element){
 
 // for links with HTTP methods other than GET
 window.addEventListener('click', function (event) {
-  if(event.target && didHandleSubmitLinkClick(event.target)) {
+  if (event.target && didHandleSubmitLinkClick(event.target)) {
     event.preventDefault();
     return false;
   }
 }, false);
+

--- a/web/static/js/phoenix_html.js
+++ b/web/static/js/phoenix_html.js
@@ -6,15 +6,15 @@ function isLinkToSubmitParent(element) {
 }
 
 function didHandleSubmitLinkClick(element) {
-  while(element) {
+  while(element && element.getAttribute) {
     if(isLinkToSubmitParent(element)) {
       var message = element.getAttribute('data-confirm');
       if (message === null || confirm(message)) {
-        element.parentElement.submit();
+        element.parentNode.submit();
       };
       return true;
     } else {
-      element = element.parentElement;
+      element = element.parentNode;
     }
   }
   return false;

--- a/web/static/js/phoenix_html.js
+++ b/web/static/js/phoenix_html.js
@@ -10,11 +10,11 @@ function didHandleSubmitLinkClick(element) {
     if(isLinkToSubmitParent(element)) {
       var message = element.getAttribute('data-confirm');
       if (message === null || confirm(message)) {
-        element.parentNode.submit();
+        element.parentElement.submit();
       };
       return true;
     } else {
-      element = element.parentNode;
+      element = element.parentElement;
     }
   }
   return false;

--- a/web/static/js/phoenix_html.js
+++ b/web/static/js/phoenix_html.js
@@ -1,6 +1,13 @@
-function didHandleSubmitLinkClick(element){
+function isLinkToSubmitParent(element) {
+  var isLinkTag = element.tagName === 'A';
+  var shouldSubmitParent = element.getAttribute('data-submit') === 'parent';
+
+  return isLinkTag && shouldSubmitParent;
+}
+
+function didHandleSubmitLinkClick(element) {
   while(element) {
-    if(element.matches && element.matches('a[data-submit=parent]')){
+    if(isLinkToSubmitParent(element)) {
       var message = element.getAttribute('data-confirm');
       if (message === null || confirm(message)) {
         element.parentNode.submit();


### PR DESCRIPTION
The JavaScript was changed in https://github.com/phoenixframework/phoenix_html/pull/77 to use `Element.matches` to find the correct element. Unfortunately, phantomjs doesn't provide that function.

This fixes that by matching the element manually.