### PR TITLE
add `multiple` field to `multiple_select` example

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -744,13 +744,13 @@ defmodule Phoenix.HTML.Form do
 
       # Assuming form contains a User schema
       multiple_select(form, :roles, ["Admin": 1, "Power User": 2])
-      #=> <select id="user_roles" name="user[roles][]">
+      #=> <select id="user_roles" multiple="" name="user[roles][]">
           <option value="1">Admin</option>
           <option value="2">Power User</option>
           </select>
 
       multiple_select(form, :roles, ["Admin": 1, "Power User": 2], value: [1])
-      #=> <select id="user_roles" name="user[roles]">
+      #=> <select id="user_roles" multiple="" name="user[roles]">
           <option value="1" selected="selected" >Admin</option>
           <option value="2">Power User</option>
           </select>


### PR DESCRIPTION
It's being added [here](https://github.com/phoenixframework/phoenix_html/blob/master/lib/phoenix_html/form.ex#L785) in the code