### PR TITLE
Implement remote links.

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -203,6 +203,12 @@ defmodule Phoenix.HTML.Tag do
         {true, opts}  -> Keyword.put(opts, :enctype, "multipart/form-data")
       end
 
+    opts =
+      case Keyword.pop(opts, :remote, false) do
+        {false, opts} -> opts
+        {true, opts} -> Keyword.put(opts, :"data-remote", "true")
+      end
+
     html_escape [tag(:form, [action: action] ++ opts), raw(extra)]
   end
 

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -25,12 +25,27 @@ defmodule Phoenix.HTML.LinkTest do
            ~s[</form>]
   end
 
+  test "link with post remote" do
+    csrf_token = Plug.CSRFProtection.get_csrf_token()
+
+    assert safe_to_string(link("hello", to: "/world", method: :post, remote: true)) ==
+           ~s[<form action="/world" class="link" data-remote="true" method="post">] <>
+           ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
+           ~s[<input to="/world" type="submit" value="hello">] <>
+           ~s[</form>]
+  end
+
   test "link with :do contents" do
     assert ~s[<a href="/hello"><p>world</p></a>] == safe_to_string(link to: "/hello" do
       Phoenix.HTML.Tag.content_tag :p, "world"
     end)
 
     assert safe_to_string(link(to: "/hello", do: "world")) == ~s[<a href="/hello">world</a>]
+  end
+
+  test "link remote" do
+    assert safe_to_string(link "world", to: "/hello", remote: true) ==
+           ~s[<a data-remote="true" href="/hello">world</a>]
   end
 
   test "link with invalid args" do


### PR DESCRIPTION
I'm playing with Phoenix and trying to implement remote forms and links using [rails-ujs](https://github.com/rails/jquery-ujs). The only discussion I found related this topic is phoenixframework/phoenix#713.
Remote forms aren't require any efforts, it's easy to set `"data-remote": "true"` and plug `rails-ujs`. But remote links aren't implemented in Phoenix.
So I gave them a try.
With `:get` links it was easy, but `:post` and other links, unlike Rails, were implemented in surprisingly different way, via forms, with links for submit.
So for `rails-ujs` to work, I had to put `"data-remote": "true"` inside forms itself, and also to replace those links with inputs with type `submit`.

As for pull request itself, I think I've introduced some more complexity and ugliness to existing code, and I wish to refactor it before merge, if it generally can be accepted.