### PR TITLE
Support for suggested syntax by @josevalim

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -659,7 +659,7 @@ defmodule Phoenix.HTML.Form do
 
   ## Optgroups
 
-  When a two-item tuple contains a list as its value,
+  When a two-item map contains a list as its value,
   the options will be wrapped in an `<optroup>` using the key as its label.
 
   ## Examples

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -735,7 +735,7 @@ defmodule Phoenix.HTML.Form do
     end
   end
 
-  defp option(group_label, group_values, value, acc) when is_list(group_values) do
+  defp option(group_label, group_values, value, acc) when is_list(group_values) or is_map(group_values) do
     section_options = options_for_select(group_values, [], value)
     tag = content_tag(:optgroup, section_options, label: group_label)
     html_escape [acc|tag]

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -472,6 +472,30 @@ defmodule Phoenix.HTML.FormTest do
            ~s(<option value="quz">quz</option>) <>
            ~s(</optgroup>) <>
            ~s(</select>)
+
+    assert safe_form(&select(&1, :key, %{"foo" => %{"1" => "One", "2" => "Two"}, "qux" => ~w(qux quz)}, value: "qux")) ==
+           ~s(<select id="search_key" name="search[key]">) <>
+           ~s(<optgroup label="foo">) <>
+           ~s(<option value="One">1</option>) <>
+           ~s(<option value="Two">2</option>) <>
+           ~s(</optgroup>) <>
+           ~s(<optgroup label="qux">) <>
+           ~s(<option selected="selected" value="qux">qux</option>) <>
+           ~s(<option value="quz">quz</option>) <>
+           ~s(</optgroup>) <>
+           ~s(</select>)
+
+    assert safe_form(&select(&1, :key, %{"foo" => [{"1", "One"}, {"2", "Two"}], "qux" => ~w(qux quz)}, value: "qux")) ==
+           ~s(<select id="search_key" name="search[key]">) <>
+           ~s(<optgroup label="foo">) <>
+           ~s(<option value="One">1</option>) <>
+           ~s(<option value="Two">2</option>) <>
+           ~s(</optgroup>) <>
+           ~s(<optgroup label="qux">) <>
+           ~s(<option selected="selected" value="qux">qux</option>) <>
+           ~s(<option value="quz">quz</option>) <>
+           ~s(</optgroup>) <>
+           ~s(</select>)
   end
 
   # multiple_select/4

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -448,6 +448,32 @@ defmodule Phoenix.HTML.FormTest do
            ~s(</select>)
   end
 
+  test "select/4 with groups" do
+    assert safe_form(&select(&1, :key, [{"foo", ~w(bar baz)}, {"qux", ~w(qux quz)}], value: "qux")) ==
+           ~s(<select id="search_key" name="search[key]">) <>
+           ~s(<optgroup label="foo">) <>
+           ~s(<option value="bar">bar</option>) <>
+           ~s(<option value="baz">baz</option>) <>
+           ~s(</optgroup>) <>
+           ~s(<optgroup label="qux">) <>
+           ~s(<option selected="selected" value="qux">qux</option>) <>
+           ~s(<option value="quz">quz</option>) <>
+           ~s(</optgroup>) <>
+           ~s(</select>)
+
+    assert safe_form(&select(&1, :key, [{"foo", [{"1", "One"}, {"2", "Two"}]}, {"qux", ~w(qux quz)}], value: "qux")) ==
+           ~s(<select id="search_key" name="search[key]">) <>
+           ~s(<optgroup label="foo">) <>
+           ~s(<option value="One">1</option>) <>
+           ~s(<option value="Two">2</option>) <>
+           ~s(</optgroup>) <>
+           ~s(<optgroup label="qux">) <>
+           ~s(<option selected="selected" value="qux">qux</option>) <>
+           ~s(<option value="quz">quz</option>) <>
+           ~s(</optgroup>) <>
+           ~s(</select>)
+  end
+
   # multiple_select/4
 
   test "multiple_select/4" do
@@ -472,6 +498,17 @@ defmodule Phoenix.HTML.FormTest do
     assert safe_to_string(multiple_select(:search, :key, [{"foo", 1}, {"bar", 2}], selected: [1])) =~
            ~s(<option selected="selected" value="1">foo</option>)
 
+    assert safe_to_string(multiple_select(:search, :key, %{"foo" => [{"One", 1}, {"Two", 2}], "bar" => ~w(3 4)})) ==
+           ~s(<select id="search_key" multiple="" name="search[key][]">) <>
+           ~s(<optgroup label="bar">) <>
+           ~s(<option value="3">3</option>) <>
+           ~s(<option value="4">4</option>) <>
+           ~s(</optgroup>) <>
+           ~s(<optgroup label="foo">) <>
+           ~s(<option value="1">One</option>) <>
+           ~s(<option value="2">Two</option>) <>
+           ~s(</optgroup>) <>
+           ~s(</select>)
   end
 
   test "multiple_select/4 with form" do


### PR DESCRIPTION
It seems to support the two other version that @josevalim suggested did already work. The only thing needed was to easy the guard on line 738 of lib/phoenix_html/form.ex to also allow for maps

I've added two more tests that cover the suggested syntax and merged the current master of phoenixframework/phoenix_html.

I've tested this on one of my own projects and everything seems fine.

Thank you @ciaran for the main work :) 