### PR TITLE
Add example for a list of ecto schema's to select

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -695,6 +695,13 @@ defmodule Phoenix.HTML.Form do
           ...
           </select>
 
+      # Assuming users is a list of User schemas and form contains a Resource Schema
+      select(form, :user_id, users |> Enum.map(&{&1.name, &1.id}))
+      #=> <select id="user_id" name="resource[user_id]">
+          <option value="1">Ylva</option>
+          <option value="2">Annora</option>
+          </select>
+
   ## Options
 
     * `:prompt` - an option to include at the top of the options with


### PR DESCRIPTION
I was struggling to find out how to actually map a list of ecto schema's to the select tag method and I found it strange that such a common use case was not mentioned in the docs. So I tried to fix that :)