### PR TITLE
Allow the submit to take a `do` option

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -524,7 +524,9 @@ defmodule Phoenix.HTML.Form do
       #=> <button type="submit">Submit</button>
 
   """
-  def submit(value, opts \\ [])
+  def submit([do: _] = block_option), do: submit([], block_option)
+
+  def submit(_, opts \\ [])
   def submit(opts, [do: _] = block_option) do
     opts = Keyword.put_new(opts, :type, "submit")
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -226,7 +226,6 @@ defmodule Phoenix.HTML.Form do
       character to force the browser to use UTF-8 as the charset. When set to
       false, this is disabled.
 
-
   See `Phoenix.HTML.Tag.form_tag/2` for more information on the
   options above.
   """
@@ -525,7 +524,14 @@ defmodule Phoenix.HTML.Form do
       #=> <button type="submit">Submit</button>
 
   """
-  def submit(value, opts \\ []) do
+  def submit(value, opts \\ [])
+  def submit(opts, [do: _] = block_option) do
+    opts = Keyword.put_new(opts, :type, "submit")
+
+    content_tag(:button, opts, block_option)
+  end
+
+  def submit(value, opts) do
     opts = Keyword.put_new(opts, :type, "submit")
 
     content_tag(:button, html_escape(value), opts)

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -321,6 +321,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(submit([class: "btn"], do: "Submit")) ==
           ~s(<button class="btn" type="submit">Submit</button>)
+
+    assert safe_to_string(submit(do: "Submit")) ==
+          ~s(<button type="submit">Submit</button>)
   end
 
   ## reset/2

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -318,6 +318,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(submit("Submit", class: "btn")) ==
           ~s(<button class="btn" type="submit">Submit</button>)
+
+    assert safe_to_string(submit([class: "btn"], do: "Submit")) ==
+          ~s(<button class="btn" type="submit">Submit</button>)
   end
 
   ## reset/2


### PR DESCRIPTION
This utilizes the `content_tag` option for taking a `do` block. The primary use case we're looking to cover is putting an SVG inside the button such as:

```elixir
<%= submit do %>
  <%= content_tag(:svg) %>
<% end %>
```