### PR TITLE
Use a button instead of an input for the button/2

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -113,12 +113,13 @@ defmodule Phoenix.HTML.Link do
 
       button("hello", to: "/world")
       #=> <form action="/world" class="button" method="post">
-            <input name="_csrf_token" value=""><input type="submit" value="hello">
+            <input name="_csrf_token" value="">
+            <button type="submit">hello</button>
           </form>
 
       button("hello", to: "/world", method: "get", class: "btn")
       #=> <form action="/world" class="btn" method="post">
-            <input type="submit" value="hello">
+            <button type="submit">hello</button>
           </form>
 
   ## Options
@@ -138,17 +139,12 @@ defmodule Phoenix.HTML.Link do
 
     {form, opts} = form_options(opts, method, "button")
 
-    opts =
-      opts
-      |> Keyword.put_new(:type, "submit")
-      |> Keyword.put_new(:value, text)
-
     unless to do
       raise ArgumentError, "option :to is required in button/2"
     end
 
     form_tag(to, form) do
-      tag(:input, opts)
+      Phoenix.HTML.Form.submit(text, opts)
     end
   end
 

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -56,14 +56,14 @@ defmodule Phoenix.HTML.LinkTest do
     assert safe_to_string(button("hello", to: "/world")) ==
            ~s[<form action="/world" class="button" method="post">] <>
            ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
-           ~s[<input type="submit" value="hello">] <>
+           ~s[<button type="submit">hello</button>] <>
            ~s[</form>]
   end
 
   test "button with get does not generate CSRF" do
     assert safe_to_string(button("hello", to: "/world", method: :get)) ==
            ~s[<form action="/world" class="button" method="get">] <>
-           ~s[<input type="submit" value="hello">] <>
+           ~s[<button type="submit">hello</button>] <>
            ~s[</form>]
   end
 
@@ -73,7 +73,7 @@ defmodule Phoenix.HTML.LinkTest do
     assert safe_to_string(button("hello", to: "/world", form: [class: "btn rounded"], id: "btn")) ==
            ~s[<form action="/world" class="btn rounded" method="post">] <>
            ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
-           ~s[<input id="btn" type="submit" value="hello">] <>
+           ~s[<button id="btn" type="submit">hello</button>] <>
            ~s[</form>]
   end
 end


### PR DESCRIPTION
This brings the `button` function in line with the change made in #95 and keeps us consistently using the `button` tag instead of the `input` tag. Also the fact that the `button` function doesn't return a button just seems weird 😄 

It also makes it easier for my next proposed change which is going to be allowing a `do:` option on the `button` function.