### PR TITLE
Submit nearest form even if not direct descendent

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -7,12 +7,22 @@ function isLinkToSubmitParent(element) {
   return isLinkTag && shouldSubmitParent;
 }
 
+function getClosestForm(element) {
+  while (element && element !== document && element.nodeType === Node.ELEMENT_NODE) {
+    if (element.tagName.toLowerCase() === 'form') {
+      return element;
+    }
+    element = element.parentNode;
+  }
+  return null;
+}
+
 function didHandleSubmitLinkClick(element) {
   while (element && element.getAttribute) {
     if (isLinkToSubmitParent(element)) {
       var message = element.getAttribute('data-confirm');
       if (message === null || confirm(message)) {
-        element.parentNode.submit();
+        getClosestForm(element).submit();
       };
       return true;
     } else {

--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -9,7 +9,7 @@ function isLinkToSubmitParent(element) {
 
 function getClosestForm(element) {
   while (element && element !== document && element.nodeType === Node.ELEMENT_NODE) {
-    if (element.tagName.toLowerCase() === 'form') {
+    if (element.tagName === 'FORM') {
       return element;
     }
     element = element.parentNode;


### PR DESCRIPTION
Hi! I'm not positive this is the right thing to do, but it solved a problem for me.

Say I have a template like this:

```
<%= form_for ... do %>
  <div id="foo">
    <%= link to: "/somewhere", class: "fa fa-save", data: [submit: "parent"] %>
  </div>
<% end %>
```

(I use `<a>` instead of `<submit>`  because I need to style the submit button with font-awesome icons e.g.)

With the original code, it tried to submit its immediate parent`div#foo`, which of course doesn't work. This PR looks for the nearest parent that is a form and submits that.
