### PR TITLE
Remove unneeded function head

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -145,8 +145,6 @@ defmodule Phoenix.HTML do
     do: {:safe, ""}
   def html_escape(bin) when is_binary(bin),
     do: {:safe, Plug.HTML.html_escape(bin)}
-  def html_escape(list) when is_list(list),
-    do: {:safe, Phoenix.HTML.Safe.List.to_iodata(list)}
   def html_escape(other),
     do: {:safe, Phoenix.HTML.Safe.to_iodata(other)}
 


### PR DESCRIPTION
The last definition of html_safe/1 should cover lists fine as the protocol is implemented for List. Afaik, you generally shouldn't reference the implementation-specific module when using protocols. The only reason I could imagine this might have been intentional is if there's some performance gain from it.