### PR TITLE
Allow passing a `do:` option to the button function

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -133,7 +133,24 @@ defmodule Phoenix.HTML.Link do
 
   All other options are forwarded to the underlying button input.
   """
+
+  def button(opts, [do: contents]) do
+    {to, form, opts} = extract_button_options(opts)
+
+    form_tag(to, form) do
+      Phoenix.HTML.Form.submit(opts, [do: contents])
+    end
+  end
+
   def button(text, opts) do
+    {to, form, opts} = extract_button_options(opts)
+
+    form_tag(to, form) do
+      Phoenix.HTML.Form.submit(text, opts)
+    end
+  end
+
+  defp extract_button_options(opts) do
     {to, opts} = Keyword.pop(opts, :to)
     {method, opts} = Keyword.pop(opts, :method, :post)
 
@@ -143,9 +160,7 @@ defmodule Phoenix.HTML.Link do
       raise ArgumentError, "option :to is required in button/2"
     end
 
-    form_tag(to, form) do
-      Phoenix.HTML.Form.submit(text, opts)
-    end
+    {to, form, opts}
   end
 
   defp form_options(opts, method, class) do

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -72,12 +72,8 @@ defmodule Phoenix.HTML.Link do
   end
 
   def link(text, opts) do
-    {to, opts} = Keyword.pop(opts, :to)
+    {to, opts} = pop_required_option!(opts, :to, "expected non-nil value for :to in link/2")
     {method, opts} = Keyword.pop(opts, :method, :get)
-
-    unless to do
-      raise ArgumentError, "expected non-nil value for :to in link/2, got: #{inspect to}"
-    end
 
     if method == :get do
       content_tag(:a, text, [href: to] ++ opts)
@@ -94,11 +90,8 @@ defmodule Phoenix.HTML.Link do
   # No docs since this function is only called when a `do` block is passed as
   # `do:` instead of `do...end` (and that case is documented in `link/2`).
   def link(opts) when is_list(opts) do
-    {contents, opts} = Keyword.pop(opts, :do)
-
-    unless contents do
-      raise ArgumentError, "link/2 requires a text as first argument or contents in the :do block"
-    end
+    error = "link/2 requires a text as first argument or contents in the :do block"
+    {contents, opts} = pop_required_option!(opts, :do, error)
 
     link(contents, opts)
   end

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -151,16 +151,22 @@ defmodule Phoenix.HTML.Link do
   end
 
   defp extract_button_options(opts) do
-    {to, opts} = Keyword.pop(opts, :to)
+    {to, opts} = pop_required_option!(opts, :to, "option :to is required in button/2")
     {method, opts} = Keyword.pop(opts, :method, :post)
 
     {form, opts} = form_options(opts, method, "button")
 
-    unless to do
-      raise ArgumentError, "option :to is required in button/2"
+    {to, form, opts}
+  end
+
+  defp pop_required_option!(opts, key, error_message) do
+    {value, opts} = Keyword.pop(opts, key)
+
+    unless value do
+      raise ArgumentError, error_message
     end
 
-    {to, form, opts}
+    {value, opts}
   end
 
   defp form_options(opts, method, class) do

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -34,7 +34,7 @@ defmodule Phoenix.HTML.LinkTest do
   end
 
   test "link with invalid args" do
-    msg = "expected non-nil value for :to in link/2, got: nil"
+    msg = "expected non-nil value for :to in link/2"
     assert_raise ArgumentError, msg, fn ->
       link("foo", [bar: "baz"])
     end

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -67,6 +67,21 @@ defmodule Phoenix.HTML.LinkTest do
            ~s[</form>]
   end
 
+  test "button with do" do
+    csrf_token = Plug.CSRFProtection.get_csrf_token()
+
+    output = safe_to_string(
+      button to: "/world", class: "small" do
+        raw("<span>Hi</span>")
+      end
+    )
+
+    assert output == ~s[<form action="/world" class="button" method="post">] <>
+      ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
+      ~s[<button class="small" type="submit"><span>Hi</span></button>] <>
+      ~s[</form>]
+  end
+
   test "button with class overrides default" do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 


### PR DESCRIPTION
We often wrap a button around svgs for things like deleting a model. This would give us markup something like:

```html
<button class="delete-icon-button">
  <svg>
    <use xlink:href="#icon-cancel-circle">
  </svg>
</button>

```

now this could be used with phoenix:
```html
<%= button to: "/", class: "delete-icon-button" do %>
  <svg>
    <use xlink:href="#icon-cancel-circle">
  </svg>
<% end %>
```

One thing to note: we are passing in `{:safe, do_option}` so that the given option is not HTML escaped. This is a bit of a security issue but I can't imagine a situation where you wouldn't want that functionality. I don't think it makes sense to require `{:safe, "<p>Hi</p>}` inside the `do` option.