### PR TITLE
Mismatching typespec for Phoenix.HTML.Form.input_validations/2

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -279,7 +279,7 @@ defmodule Phoenix.HTML.Form do
   Returns the HTML5 validations that would apply to
   the given field.
   """
-  @spec input_validations(t, atom) :: boolean
+  @spec input_validations(t, atom) :: Keyword.t
   def input_validations(form, field) do
     form.impl.input_validations(form.source, field)
   end


### PR DESCRIPTION
Hi! It seems like the typespec for [`Phoenix.HTML.Form.input_validations/2`](https://github.com/phoenixframework/phoenix_html/blob/30c437b231ca48516097e166ae4fddb95bfd8b81/lib/phoenix_html/form.ex#L282) should be changed to `Keyword.t` as the return type, to match up with [`Phoenix.HTML.FormData.input_validations/2`](https://github.com/phoenixframework/phoenix_html/blob/9efece91e4c77df97e0e95087d35ef18f05af0f4/lib/phoenix_html/form_data.ex#L33).