### PR TITLE
Add img/2 function for img tags

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -244,4 +244,20 @@ defmodule Phoenix.HTML.Tag do
     tag :meta, charset: "UTF-8", name: "csrf-token", content: get_csrf_token(),
                'csrf-param': @csrf_param, 'method-param': @method_param
   end
+
+  @doc """
+  Generates an img tag with a src.
+
+  ## Examples
+
+      img(user.photo_path)
+      <img src="photo.png">
+
+      img(user.photo, class: "image")
+      <img src="smile.png" class="image">
+  """
+  def img(src, opts \\ []) do
+    opts = Keyword.merge([src: src], opts)
+    tag(:img, opts)
+  end
 end

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -91,6 +91,13 @@ defmodule Phoenix.HTML.TagTest do
            "<p>hello world</p>"
   end
 
+  test "img_tag" do
+    assert img("user.png") |> safe_to_string() == ~s(<img src="user.png">)
+
+    assert img("user.png", [class: "big"]) |> safe_to_string() ==
+      ~s(<img class="big" src="user.png">)
+  end
+
   test "form_tag for get" do
     assert safe_to_string(form_tag("/", method: :get)) ==
            ~s(<form accept-charset="UTF-8" action="/" method="get">) <>


### PR DESCRIPTION
Fixes #129 

I wasn't sure if I should go with `img` or `img_tag`. The `button/2` function doesn't have `_tag`, nor does `form_for`. I think personally I prefer it without the unnecessary `_tag` but I could argue either way!