### PR TITLE
Test against Elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: elixir
-elixir:
-  - "1.2.5"
-  - "1.3.2"
-otp_release:
-  - 18.1
+matrix:
+  include:
+    - otp_release: 18.3
+      elixir: 1.2.6
+    - otp_release: 18.3
+      elixir: 1.3.2
+    - otp_release: 19.2
+      elixir: 1.3.2
+    - otp_release: 18.3
+      elixir: 1.4.0
+    - otp_release: 19.2
+      elixir: 1.4.0
 sudo: false
 before_script:
   - mix deps.get --only test


### PR DESCRIPTION
This PR adds Elixir 1.4 and latest OTP 19.2 to the travis ci test suite.

Cheers.