### PR TITLE
Remove guard is_atom(field) from input_value/2 without form, add tests

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -299,7 +299,7 @@ defmodule Phoenix.HTML.Form do
     end
   end
 
-  def input_value(name, field) when is_atom(name) and is_atom(field),
+  def input_value(name, field) when is_atom(name),
     do: nil
 
   @doc """

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -841,6 +841,8 @@ defmodule Phoenix.HTML.FormTest do
 
   test "input_value/2 without form" do
     assert input_value(:search, :key) == nil
+    assert input_value(:search, 1) == nil
+    assert input_value(:search, "key") == nil
   end
 
   test "input_value/2 with form" do


### PR DESCRIPTION
Avoid `(FunctionClauseError) no function clause matching in Phoenix.HTML.Form.input_value/2` if field is not an atom.

According [this discussion](https://github.com/phoenixframework/phoenix_html/issues/140).