### PR TITLE
Add date, datetime and time input types

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -518,8 +518,8 @@ defmodule Phoenix.HTML.Form do
 
   See `text_input/3` for example and docs.
   """
-  def datetime_input(form, field, opts \\ []) do
-    generic_input(:datetime, form, field, opts)
+  def datetime_local_input(form, field, opts \\ []) do
+    generic_input(:'datetime-local', form, field, opts)
   end
 
   @doc """

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -498,6 +498,42 @@ defmodule Phoenix.HTML.Form do
     generic_input(:range, form, field, opts)
   end
 
+  @doc """
+  Generates a date input.
+
+  Warning: this feature isn't available in all browsers.
+  Check `http://caniuse.com/#feat=input-datetime` for further informations.
+
+  See `text_input/3` for example and docs.
+  """
+  def date_input(form, field, opts \\ []) do
+    generic_input(:date, form, field, opts)
+  end
+
+  @doc """
+  Generates a datetime input.
+
+  Warning: this feature isn't available in all browsers.
+  Check `http://caniuse.com/#feat=input-datetime` for further informations.
+
+  See `text_input/3` for example and docs.
+  """
+  def datetime_input(form, field, opts \\ []) do
+    generic_input(:datetime, form, field, opts)
+  end
+
+  @doc """
+  Generates a time input.
+
+  Warning: this feature isn't available in all browsers.
+  Check `http://caniuse.com/#feat=input-datetime` for further informations.
+
+  See `text_input/3` for example and docs.
+  """
+  def time_input(form, field, opts \\ []) do
+    generic_input(:time, form, field, opts)
+  end
+
   defp generic_input(type, form, field, opts) when is_atom(field) and is_list(opts) do
     opts =
       opts

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -333,20 +333,20 @@ defmodule Phoenix.HTML.FormTest do
 
   ## datetime_input/3
 
-  test "datetime_input/3" do
-    assert safe_to_string(datetime_input(:search, :key)) ==
-          ~s(<input id="search_key" name="search[key]" type="datetime">)
+  test "datetime_local_input/3" do
+    assert safe_to_string(datetime_local_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime-local">)
 
-    assert safe_to_string(datetime_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
-          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+    assert safe_to_string(datetime_local_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)
   end
 
-  test "datetime_input/3 with form" do
-    assert safe_form(&datetime_input(&1, :key)) ==
-          ~s(<input id="search_key" name="search[key]" type="datetime" value="value">)
+  test "datetime_local_input/3 with form" do
+    assert safe_form(&datetime_local_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime-local" value="value">)
 
-    assert safe_form(&datetime_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
-          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+    assert safe_form(&datetime_local_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)
   end
 
   ## time_input/3

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -295,7 +295,7 @@ defmodule Phoenix.HTML.FormTest do
           ~s(<input id="key" name="search[key][]" type="tel" value="foo">)
   end
 
-  ## date_input/3
+  ## range_input/3
 
   test "range_input/3" do
     assert safe_to_string(range_input(:search, :key)) ==

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -209,9 +209,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(file_input(:search, :key, id: "key", name: "search[key][]")) ==
            ~s(<input id="key" name="search[key][]" type="file">)
-        
+
     assert safe_to_string(file_input(:search, :key, multiple: true)) ==
-           ~s(<input id="search_key" multiple="multiple" name="search[key][]" type="file">)  
+           ~s(<input id="search_key" multiple="multiple" name="search[key][]" type="file">)
   end
 
   test "file_input/3 with form" do
@@ -295,7 +295,7 @@ defmodule Phoenix.HTML.FormTest do
           ~s(<input id="key" name="search[key][]" type="tel" value="foo">)
   end
 
-  ## range_input/3
+  ## date_input/3
 
   test "range_input/3" do
     assert safe_to_string(range_input(:search, :key)) ==
@@ -311,6 +311,60 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_form(&range_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="range" value="foo">)
+  end
+
+  ## date_input/3
+
+  test "date_input/3" do
+    assert safe_to_string(date_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="date">)
+
+    assert safe_to_string(date_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="date" value="foo">)
+  end
+
+  test "date_input/3 with form" do
+    assert safe_form(&date_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="date" value="value">)
+
+    assert safe_form(&date_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="date" value="foo">)
+  end
+
+  ## datetime_input/3
+
+  test "datetime_input/3" do
+    assert safe_to_string(datetime_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime">)
+
+    assert safe_to_string(datetime_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+  end
+
+  test "datetime_input/3 with form" do
+    assert safe_form(&datetime_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime" value="value">)
+
+    assert safe_form(&datetime_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+  end
+
+  ## time_input/3
+
+  test "time_input/3" do
+    assert safe_to_string(time_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="time">)
+
+    assert safe_to_string(time_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="time" value="foo">)
+  end
+
+  test "time_input/3 with form" do
+    assert safe_form(&time_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="time" value="value">)
+
+    assert safe_form(&time_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="time" value="foo">)
   end
 
   ## submit/2


### PR DESCRIPTION
Hi, I miss date and time input types. 

I think input[type=datetime] it's necessary for using native datepickers on modern and mobile browsers .