### PR TITLE
Adds clarification of extra options on `form_for`

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -225,6 +225,9 @@ defmodule Phoenix.HTML.Form do
       to "UTF-8" and a hidden input named `_utf8` containing a unicode
       character to force the browser to use UTF-8 as the charset. When set to
       false, this is disabled.
+     
+    * Other options will be passed as html attributes.
+      ie, `class: "foo", id: "bar"`
 
   See `Phoenix.HTML.Tag.form_tag/2` for more information on the
   options above.


### PR DESCRIPTION
I saw someone asking how to set a class on a form and not
finding anything about it in the documentation. I thought
this is a common enough thing that we should add it to the
documentation.

Amos King @adkron <amos@binarynoggin.com>