### PR TITLE
Add support for generating a multiple options select to `select/4`

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -775,6 +775,12 @@ defmodule Phoenix.HTML.Form do
           <option value="user">User</option>
           </select>
 
+      select(form, :roles, ["Admin": 1, "Power User": 2], multiple: true, selected: [1])
+      #=> <select id="user_roles" name="user[roles][]">
+          <option value="1" selected="selected" >Admin</option>
+          <option value="2">Power User</option>
+          </select>
+
   If you want to select an option that comes from the database,
   such as a manager for a given project, you may write:
 
@@ -799,6 +805,11 @@ defmodule Phoenix.HTML.Form do
 
   ## Options
 
+    * `multiple` - When set to any value other than `false` or `nil` the
+      generated select is a multiple select. Unless explicitly provided,
+      the name attribute has `[]` appended to it, in order to signal to
+      the params parser that the selected values should go in an array.
+
     * `:prompt` - an option to include at the top of the options with
       the given prompt text
 
@@ -814,12 +825,29 @@ defmodule Phoenix.HTML.Form do
       {prompt, opts} -> {content_tag(:option, prompt, value: ""), opts}
     end
 
-    opts =
-      opts
-      |> Keyword.put_new(:id, input_id(form, field))
-      |> Keyword.put_new(:name, input_name(form, field))
+    {multiple, opts} = case Keyword.pop(opts, :multiple) do
+      {nil, opts} -> {false, opts}
+      {false, opts} -> {false, opts}
+      {_, opts} -> {true, opts}
+    end
 
-    options = options_for_select(options, prefix, html_escape(selected))
+    opts = Keyword.put_new(opts, :id, input_id(form, field))
+
+    opts =
+      if multiple do
+        opts |> Keyword.put_new(:name, input_name(form, field) <> "[]")
+             |> Keyword.put(:multiple, "")
+      else
+        opts |> Keyword.put_new(:name, input_name(form, field))
+      end
+
+    options =
+      if multiple do
+        options |> options_for_select("", Enum.map(List.wrap(selected), &html_escape/1))
+      else
+        options |> options_for_select(prefix, html_escape(selected))
+      end
+
     content_tag(:select, options, opts)
   end
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -925,7 +925,7 @@ defmodule Phoenix.HTML.Form do
           </select>
 
       multiple_select(form, :roles, ["Admin": 1, "Power User": 2], selected: [1])
-      #=> <select id="user_roles" name="user[roles]">
+      #=> <select id="user_roles" name="user[roles][]">
           <option value="1" selected="selected" >Admin</option>
           <option value="2">Power User</option>
           </select>
@@ -948,16 +948,12 @@ defmodule Phoenix.HTML.Form do
   All other options are forwarded to the underlying HTML tag.
   """
   def multiple_select(form, field, options, opts \\ []) do
-    {selected, opts} = selected(form, field, opts)
+    # TODO: Deprecate after backwards compatibility period; remove tests and update docs.
+    # IO.puts :stderr, "warning: `Phoenix.HTML.Form.multiple_select/4` is deprecated," <>
+    #                  "please use `select/4` with `multiple: true` option instead\n" <> Exception.format_stacktrace
 
-    opts =
-      opts
-      |> Keyword.put_new(:id, input_id(form, field))
-      |> Keyword.put_new(:name, input_name(form, field) <> "[]")
-      |> Keyword.put_new(:multiple, "")
-
-    options = options_for_select(options, "", Enum.map(List.wrap(selected), &html_escape/1))
-    content_tag(:select, options, opts)
+    opts = Keyword.put_new(opts, :multiple, "")
+    select(form, field, options, opts)
   end
 
   ## Datetime

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -533,6 +533,40 @@ defmodule Phoenix.HTML.FormTest do
            ~s(</select>)
   end
 
+  test "select/4 with multiple" do
+    assert safe_to_string(select(:search, :key, ~w(foo bar), multiple: true)) ==
+        ~s(<select id="search_key" multiple="" name="search[key][]">) <>
+        ~s(<option value="foo">foo</option>) <>
+        ~s(<option value="bar">bar</option>) <>
+        ~s(</select>)
+
+    assert safe_to_string(select(:search, :key, ~w(foo bar), multiple: false)) ==
+        ~s(<select id="search_key" name="search[key]">) <>
+        ~s(<option value="foo">foo</option>) <>
+        ~s(<option value="bar">bar</option>) <>
+        ~s(</select>)
+
+    assert safe_to_string(select(:search, :key, ~w(foo bar), multiple: nil)) ==
+        ~s(<select id="search_key" name="search[key]">) <>
+        ~s(<option value="foo">foo</option>) <>
+        ~s(<option value="bar">bar</option>) <>
+        ~s(</select>)
+
+    assert safe_to_string(select(:search, :key, ~w(foo bar baz), multiple: true, selected: ["foo", "baz"])) ==
+        ~s(<select id="search_key" multiple="" name="search[key][]">) <>
+        ~s(<option selected="selected" value="foo">foo</option>) <>
+        ~s(<option value="bar">bar</option>) <>
+        ~s(<option selected="selected" value="baz">baz</option>) <>
+        ~s(</select>)
+
+    assert safe_to_string(select(:search, :key, ~w(foo bar baz), name: "query", multiple: true, selected: ["foo", "baz"])) ==
+        ~s(<select id="search_key" multiple="" name="query">) <>
+        ~s(<option selected="selected" value="foo">foo</option>) <>
+        ~s(<option value="bar">bar</option>) <>
+        ~s(<option selected="selected" value="baz">baz</option>) <>
+        ~s(</select>)
+  end
+
   # multiple_select/4
 
   test "multiple_select/4" do


### PR DESCRIPTION
As a Rails developer, I was surprised when I tried to generate a multiple options select with `select f, :categories, @categories, multiple: true` and it didn't work.

This PR adds support for doing just that. It also replaces the implementation of `multiple_select/4` to call `select/4` with the applicable arguments instead.

My personal preference would be to deprecate `multiple_select` in favour of `select/4` thus reducing the cognitive dissonance especially for Rails developers many of whom are moving to Phoenix. To that end I've added a (commented out) deprecation block, as I've seen done in other parts of the project. If the maintainers decide that they don't want to deprecate, let me know and I can remove that commit.

I am an Elixir newbie, so even though I've spent a fair amount of time trying to avoid `if/else` I couldn't see the functional way of implementing this without re-writting a large portion of the helpers. I am open to feedback though. :)