### PR TITLE
Offer advice in documentation of select/4 for creating multiple selects

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -804,6 +804,9 @@ defmodule Phoenix.HTML.Form do
 
     * `:selected` - the default value to use when none was sent as parameter
 
+  Be aware that a `:multiple` option will not generate a correctly
+  functioning multiple select element. Use `multiple_select/4` instead.
+
   All other options are forwarded to the underlying HTML tag.
   """
   def select(form, field, options, opts \\ []) do


### PR DESCRIPTION
A small documentation patch to clarify that `select/4` should not be used to create multiple selection elements; `multiple_select/4` should be used instead.

As per @josevalim's [suggestion](https://github.com/phoenixframework/phoenix_html/pull/147#issuecomment-283939145).