### PR TITLE
Remove Elixir 1.5 deprecation warning

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1134,8 +1134,8 @@ defmodule Phoenix.HTML.Form do
   ]
 
   map = &Enum.map(&1, fn i ->
-    i = Integer.to_string(i)
-    {String.rjust(i, 2, ?0), i}
+    pre = if i < 9, do: "0"
+    {"#{pre}#{i}", i}
   end)
 
   @days   map.(1..31)


### PR DESCRIPTION
We could use the newer pad_leading but that would break compatibility
with Elixir < 1.3