### PR TITLE
Fixed behavior of links (#151)

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -22,6 +22,10 @@ defmodule Phoenix.HTML.Link do
       link("delete", to: "/the_world", data: [confirm: "Really?"])
       #=> <a data-confirm="Really?" href="/the_world">delete</a>
 
+      # If you supply a method other than `:get`:
+      link("delete", to: "/everything", method: :delete)
+      #=> <a href="#" data-csrf="csrf_token" data-method="delete" data-to="/everything">delete</a>
+
       # You can use a `do ... end` block too:
       link to: "/hello" do
         "world"
@@ -36,9 +40,6 @@ defmodule Phoenix.HTML.Link do
       which sets the proper information. In order to submit the
       form, JavaScript must be enabled
 
-    * `:form` - customize the underlying form when the method
-      is not `:get`
-
   All other options are forwarded to the underlying `<a>` tag.
 
   ## Data attributes
@@ -46,17 +47,15 @@ defmodule Phoenix.HTML.Link do
   Data attributes are added as a keyword list passed to the
   `data` key. The following data attributes are supported:
 
-    * `data-submit="parent"` - automatically used when the
-      `:method` is not `:get`, this module attribute says the
-      underlying link should submit the parent form on click
-
     * `data-confirm` - shows a confirmation prompt before
-      submitting the parent when `:method` is not `:get`.
+      generating and submitting the form when `:method`
+      is not `:get`.
 
   ## JavaScript dependency
 
-  In order to support the data attributes above, `Phoenix.HTML`
-  relies on JavaScript. You can either load the ES5 version from
+  In order to support links where `:method` is not `:get`
+  or use the above data attributes, `Phoenix.HTML` relies
+  on JavaScript. You can either load the ES5 version from
   `priv/static/phoenix_html.js` or depend on the one at
   `web/static/js/phoenix_html.js` written in ES6 directly from
   your build tool.
@@ -79,10 +78,8 @@ defmodule Phoenix.HTML.Link do
       content_tag(:a, text, [href: to] ++ opts)
     else
       opts = Keyword.put_new(opts, :rel, "nofollow")
-      {form, opts} = form_options(opts, method, "link")
-      form_tag(to, form) do
-        content_tag(:a, text, [href: "#", data: [submit: "parent"]] ++ opts)
-      end
+      csrf_token = Plug.CSRFProtection.get_csrf_token()
+      content_tag(:a, text, [href: "#", data: [csrf: csrf_token, method: method, to: to]] ++ opts)
     end
   end
 
@@ -105,15 +102,10 @@ defmodule Phoenix.HTML.Link do
   ## Examples
 
       button("hello", to: "/world")
-      #=> <form action="/world" class="button" method="post">
-            <input name="_csrf_token" value="">
-            <button type="submit">hello</button>
-          </form>
+      #=> <button class="button" data-csrf="csrf_token" data-method="post" data-to="/world">hello</button>
 
       button("hello", to: "/world", method: "get", class: "btn")
-      #=> <form action="/world" class="btn" method="get">
-            <button type="submit">hello</button>
-          </form>
+      #=> <button class="btn" data-method="get" data-to="/world">hello</button>
 
   ## Options
 
@@ -121,24 +113,20 @@ defmodule Phoenix.HTML.Link do
 
     * `:method` - the method to use with the button. Defaults to :post.
 
-    * `:form` - the options for the form. Defaults to
-      `[class: "button", enforce_utf8: false]`
-
   All other options are forwarded to the underlying button input.
   """
   def button(opts, [do: contents]) do
-    {to, form, opts} = extract_button_options(opts)
-
-    form_tag(to, form) do
-      Phoenix.HTML.Form.submit(opts, [do: contents])
-    end
+    button(contents, opts)
   end
 
   def button(text, opts) do
-    {to, form, opts} = extract_button_options(opts)
+    {to, method, opts} = extract_button_options(opts)
 
-    form_tag(to, form) do
-      Phoenix.HTML.Form.submit(text, opts)
+    if method == :get do
+      content_tag(:button, text, [data: [method: method, to: to]] ++ opts)
+    else
+      csrf_token = Plug.CSRFProtection.get_csrf_token()
+      content_tag(:button, text, [data: [csrf: csrf_token, method: method, to: to]] ++ opts)
     end
   end
 
@@ -146,9 +134,7 @@ defmodule Phoenix.HTML.Link do
     {to, opts} = pop_required_option!(opts, :to, "option :to is required in button/2")
     {method, opts} = Keyword.pop(opts, :method, :post)
 
-    {form, opts} = form_options(opts, method, "button")
-
-    {to, form, opts}
+    {to, method, opts}
   end
 
   defp pop_required_option!(opts, key, error_message) do
@@ -159,17 +145,5 @@ defmodule Phoenix.HTML.Link do
     end
 
     {value, opts}
-  end
-
-  defp form_options(opts, method, class) do
-    {form, opts} = Keyword.pop(opts, :form, [])
-
-    form =
-      form
-      |> Keyword.put_new(:class, class)
-      |> Keyword.put_new(:method, method)
-      |> Keyword.put_new(:enforce_utf8, false)
-
-    {form, opts}
   end
 end

--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -1,41 +1,38 @@
-'use strict';
+"use strict";
 
-function isLinkToSubmitParent(element) {
-  var isLinkTag = element.tagName === 'A';
-  var shouldSubmitParent = element.getAttribute('data-submit') === 'parent';
+(function() {
+  function buildHiddenInput(name, value) {
+    var input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    return input;
+  }
 
-  return isLinkTag && shouldSubmitParent;
-}
-
-function getClosestForm(element) {
-  while (element && element !== document && element.nodeType === Node.ELEMENT_NODE) {
-    if (element.tagName === 'FORM') {
-      return element;
+  function handleLinkClick(link) {
+    var message = link.getAttribute("data-confirm");
+    if(message && !window.confirm(message)) {
+        return;
     }
-    element = element.parentNode;
-  }
-  return null;
-}
 
-function didHandleSubmitLinkClick(element) {
-  while (element && element.getAttribute) {
-    if (isLinkToSubmitParent(element)) {
-      var message = element.getAttribute('data-confirm');
-      if (message === null || confirm(message)) {
-        getClosestForm(element).submit();
-      }
-      return true;
-    } else {
-      element = element.parentNode;
+    var to = link.getAttribute("data-to"),
+        method = buildHiddenInput("_method", link.getAttribute("data-method")),
+        csrf = buildHiddenInput("_csrf_token", link.getAttribute("data-csrf")),
+        form = document.createElement("form");
+
+    form.method = "post";
+    form.action = to;
+    form.style.display = "hidden";
+
+    form.appendChild(csrf);
+    form.appendChild(method);
+    document.body.appendChild(form);
+    form.submit();
+  }
+
+  window.addEventListener("click", function(e) {
+    if(e.target && e.target.getAttribute("data-method")) {
+      handleLinkClick(e.target);
     }
-  }
-  return false;
-}
-
-window.addEventListener('click', function (event) {
-  if (event.target && didHandleSubmitLinkClick(event.target)) {
-    event.preventDefault();
-    return false;
-  }
-}, false);
-
+  }, false);
+})();

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -8,21 +8,14 @@ defmodule Phoenix.HTML.LinkTest do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(link("hello", to: "/world", method: :post)) ==
-           ~s[<form action="/world" class="link" method="post">] <>
-           ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
-           ~s[<a data-submit="parent" href="#" rel="nofollow">hello</a>] <>
-           ~s[</form>]
+           ~s[<a data-csrf="#{csrf_token}" data-method="post" data-to="/world" href="#" rel="nofollow">hello</a>]
   end
 
   test "link with put/delete" do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
-    assert safe_to_string(link("hello", to: "/world", method: :put, form: [class: "linkmethod"])) ==
-           ~s[<form action="/world" class="linkmethod" method="post">] <>
-           ~s[<input name="_method" type="hidden" value="put">] <>
-           ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
-           ~s[<a data-submit="parent" href="#" rel="nofollow">hello</a>] <>
-           ~s[</form>]
+    assert safe_to_string(link("hello", to: "/world", method: :put)) ==
+           ~s[<a data-csrf="#{csrf_token}" data-method="put" data-to="/world" href="#" rel="nofollow">hello</a>]
   end
 
   test "link with :do contents" do
@@ -54,17 +47,12 @@ defmodule Phoenix.HTML.LinkTest do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(button("hello", to: "/world")) ==
-           ~s[<form action="/world" class="button" method="post">] <>
-           ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
-           ~s[<button type="submit">hello</button>] <>
-           ~s[</form>]
+          ~s[<button data-csrf="#{csrf_token}" data-method="post" data-to="/world">hello</button>]
   end
 
   test "button with get does not generate CSRF" do
     assert safe_to_string(button("hello", to: "/world", method: :get)) ==
-           ~s[<form action="/world" class="button" method="get">] <>
-           ~s[<button type="submit">hello</button>] <>
-           ~s[</form>]
+          ~s[<button data-method="get" data-to="/world">hello</button>]
   end
 
   test "button with do" do
@@ -76,19 +64,14 @@ defmodule Phoenix.HTML.LinkTest do
       end
     )
 
-    assert output == ~s[<form action="/world" class="button" method="post">] <>
-      ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
-      ~s[<button class="small" type="submit"><span>Hi</span></button>] <>
-      ~s[</form>]
+    assert output ==
+           ~s[<button class="small" data-csrf="#{csrf_token}" data-method="post" data-to="/world"><span>Hi</span></button>]
   end
 
   test "button with class overrides default" do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
-    assert safe_to_string(button("hello", to: "/world", form: [class: "btn rounded"], id: "btn")) ==
-           ~s[<form action="/world" class="btn rounded" method="post">] <>
-           ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
-           ~s[<button id="btn" type="submit">hello</button>] <>
-           ~s[</form>]
+    assert safe_to_string(button("hello", to: "/world", class: "btn rounded", id: "btn")) ==
+           ~s[<button class="btn rounded" data-csrf="#{csrf_token}" data-method="post" data-to="/world" id="btn">hello</button>]
   end
 end

--- a/web/static/js/phoenix_html.js
+++ b/web/static/js/phoenix_html.js
@@ -1,38 +1,38 @@
-function isLinkToSubmitParent(element) {
-  var isLinkTag = element.tagName === 'A';
-  var shouldSubmitParent = element.getAttribute('data-submit') === 'parent';
+"use strict";
 
-  return isLinkTag && shouldSubmitParent;
-}
+(function() {
+  function buildHiddenInput(name, value) {
+    var input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    return input;
+  }
 
-function getClosestForm(element) {
-  while (element && element !== document && element.nodeType === Node.ELEMENT_NODE) {
-    if (element.tagName === 'FORM') {
-      return element;
+  function handleLinkClick(link) {
+    var message = link.getAttribute("data-confirm");
+    if(message && !window.confirm(message)) {
+        return;
     }
-    element = element.parentNode;
-  }
-  return null;
-}
 
-function didHandleSubmitLinkClick(element) {
-  while (element && element.getAttribute) {
-    if (isLinkToSubmitParent(element)) {
-      var message = element.getAttribute('data-confirm');
-      if (message === null || confirm(message)) {
-        getClosestForm(element).submit();
-      }
-      return true;
-    } else {
-      element = element.parentNode;
+    var to = link.getAttribute("data-to"),
+        method = buildHiddenInput("_method", link.getAttribute("data-method")),
+        csrf = buildHiddenInput("_csrf_token", link.getAttribute("data-csrf")),
+        form = document.createElement("form");
+
+    form.method = "post";
+    form.action = to;
+    form.style.display = "hidden";
+
+    form.appendChild(csrf);
+    form.appendChild(method);
+    document.body.appendChild(form);
+    form.submit();
+  }
+
+  window.addEventListener("click", function(e) {
+    if(e.target && e.target.getAttribute("data-method")) {
+      handleLinkClick(e.target);
     }
-  }
-  return false;
-}
-
-window.addEventListener('click', function (event) {
-  if (event.target && didHandleSubmitLinkClick(event.target)) {
-    event.preventDefault();
-    return false;
-  }
-}, false);
+  }, false);
+})();


### PR DESCRIPTION
Links with a `:method` other than `:get` no longer create inline forms.

This caused issues with nesting as layed out in #151. Now the forms are
generated, appended to the end of `<body>`, and submitted via Javascript
when the link is clicked.

The new links -- with the options set -- are rendered as follows: `<a
href="#" data-csrf="#{csrf_token}" data-method="#{method}"
data-to="#{to}">#{text}</a>`.

As part of this change `data-submit="parent"` is deprecated, and
`data-method="#{method}"` and `data-csrf="#{csrf_token}"` are introduced.