### PR TITLE
Change sigil_e delimiter for improved documentation rendering

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -951,7 +951,7 @@ defmodule Phoenix.HTML.Form do
 
   ## Datetime
 
-  @doc ~S"""
+  @doc ~S'''
   Generates select tags for datetime.
 
   ## Examples
@@ -1013,10 +1013,10 @@ defmodule Phoenix.HTML.Form do
 
       def my_datetime_select(form, field, opts \\ []) do
         builder = fn b ->
-          ~e'''
+          ~e"""
           Date: <%= b.(:day, []) %> / <%= b.(:month, []) %> / <%= b.(:year, []) %>
           Time: <%= b.(:hour, []) %> : <%= b.(:minute, []) %>
-          '''
+          """
         end
 
         datetime_select(form, field, [builder: builder] ++ opts)
@@ -1042,7 +1042,7 @@ defmodule Phoenix.HTML.Form do
     * a tuple with four elements: `{hour, min, sec, usec}`
     * `nil`
 
-  """
+  '''
   def datetime_select(form, field, opts \\ []) do
     value = Keyword.get(opts, :value, input_value(form, field) || Keyword.get(opts, :default))
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1013,10 +1013,10 @@ defmodule Phoenix.HTML.Form do
 
       def my_datetime_select(form, field, opts \\ []) do
         builder = fn b ->
-          ~e"\""
+          ~e'''
           Date: <%= b.(:day, []) %> / <%= b.(:month, []) %> / <%= b.(:year, []) %>
           Time: <%= b.(:hour, []) %> : <%= b.(:minute, []) %>
-          "\""
+          '''
         end
 
         datetime_select(form, field, [builder: builder] ++ opts)


### PR DESCRIPTION
As the docs use `~S"""..."""` by convention, and the example sigil shown
in these docs was also trying to use `"""` as its delimiter, a `\` had
been inserted to avoid breaking out of the original string.

This of course meant the `\` was rendering in the documentation, which
seems less than ideal (you can see this in action at
https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#datetime_select/3).

Fixed by using an alternative delimiter. I picked `'''`, which is
hopefully not too controversial?