### PR TITLE
Fix ArgumentError in Phoenix.HTML.Form.textarea/3

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -557,7 +557,7 @@ defmodule Phoenix.HTML.Form do
       |> Keyword.put_new(:name, input_name(form, field))
 
     {value, opts} = Keyword.pop(opts, :value, input_value(form, field) || "")
-    content_tag(:textarea, html_escape(["\n", value]), opts)
+    content_tag(:textarea, ["\n", html_escape(value)], opts)
   end
 
   @doc """

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -129,6 +129,11 @@ defmodule Phoenix.HTML.FormTest do
            ~s(<textarea id="key" name="search[key][]">\nfoo</textarea>)
   end
 
+  test "textarea/3 with non-binary type" do
+    assert safe_form(&textarea(&1, :key, value: :atom_value)) ==
+           ~s(<textarea id="search_key" name="search[key]">\natom_value</textarea>)
+  end
+
   ## number_input/3
 
   test "number_input/3" do


### PR DESCRIPTION
Passing a type other than binary to `Phoenix.HTML.Form.textarea/3` as the `value` option raises an error:

```
** (ArgumentError) lists in Phoenix.HTML and templates may only contain integers representing bytes, binaries or other lists, got invalid entry: ...
```

**Expected behavior:** the function should accept any data structure that implements the `Phoenix.HTML.Safe` protocol.

This seems like an easy fix to me, but I might be missing something important, so any feedback is appreciated :smiley: