### PR TITLE
Add support for Bootstrap modals

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+* The underneath has been adapted from:
+* https://github.com/phoenixframework/phoenix_html/blob/51b0866afb3907cda652b94e8be77bc6929608d7/priv/static/phoenix_html.js
+*/
 function isLinkToSubmitParent(element) {
   var isLinkTag = element.tagName === 'A';
   var shouldSubmitParent = element.getAttribute('data-submit') === 'parent';
@@ -21,7 +25,11 @@ function didHandleSubmitLinkClick(element) {
   while (element && element.getAttribute) {
     if (isLinkToSubmitParent(element)) {
       var message = element.getAttribute('data-confirm');
-      if (message === null || confirm(message)) {
+      if (typeof(window.jQuery) != undefined && $('#phoenix-bs-modal').length) {
+        willHandleConfirmLinkClick($('#phoenix-bs-modal'), message).then(function (e) {
+          getClosestForm(element).submit();
+        });
+      } else if (message === null || confirm(message)) {
         getClosestForm(element).submit();
       }
       return true;
@@ -39,3 +47,30 @@ window.addEventListener('click', function (event) {
   }
 }, false);
 
+/**
+* willHandleConfirmLinkClick (modal, message) takes a jQuery DOM element and
+*   a message string (optional). modal is expected to conform loosely to the
+*   Bootstrap modal component described at
+*   https://getbootstrap.com/javascript/#modals
+*
+* willHandleConfirmLinkClick return a Promise object that resolves if and only
+*   the user confirms his/her input by clicking the '.btn-primary' button in the
+*   modal dialogue.
+*/
+function willHandleConfirmLinkClick(modal, message) {
+  return new Promise((resolve, reject) => {
+    modal.on('show.bs.modal', function(e) {
+      if (message !== null) {
+        modal.find('.modal-body p').text(message);
+      }
+      modal.find('.btn-primary').click(function(e) {
+        modal.modal('hide');
+        resolve();
+      });
+    });
+    modal.on('hide.bs.modal', function(e) {
+      modal.find('.btn-primary').off('click');
+    });
+    modal.modal('show');
+  });
+}


### PR DESCRIPTION
I'm no fan of the blocking browser confirmation dialogues currently used for delete confirmation by phoenix_html. I've therefore implemented the delegation of this dialogue to a [Bootstrap modal](https://getbootstrap.com/javascript/#modals) if (and only if) jQuery is available and a suitable DOM element is present.

This seems reasonable to me since Phoenix ships with Bootstrap out of the box.

Example Bootstrap modal:

![bs-modal](https://user-images.githubusercontent.com/634149/27681076-40e56444-5cbe-11e7-806e-dba442b97df8.png)

Delegation of the confirmation dialogue to a Bootstrap modal requires only that one adds some HTML to the template that (roughly) conforms to the following code:

```html
<div class="modal fade" id="phoenix-bs-modal" tabindex="-1" role="dialog">
  <div class="modal-dialog" role="document">
    <div class="modal-content">
      <div class="modal-header">
        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
        <h4 class="modal-title">Modal title</h4>
      </div>
      <div class="modal-body">
        <p>One fine body&hellip;</p>
      </div>
      <div class="modal-footer">
        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
        <button type="button" class="btn btn-primary">Save changes</button>
      </div>
    </div><!-- /.modal-content -->
  </div><!-- /.modal-dialog -->
</div><!-- /.modal -->
```

Important are a `div.modal#phoenix-bs-modal` element and a `.btn-primary` child element. The message passed in via the data-confirm attribute on the delete link is forwarded to the modal body.

I'm proposing this pull request as I believe that this is as some functionality that others could be interested in. Please note that I'm no Javascript expert. If you decide to pull in these changes, than a code review by someone more capable than I am would be a very good idea ;-)


