### PR TITLE
Wrap button/link with data-method="get" in form with same method

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -20,7 +20,7 @@
         csrf = buildHiddenInput("_csrf_token", link.getAttribute("data-csrf")),
         form = document.createElement("form");
 
-    form.method = "post";
+    form.method = (link.getAttribute("data-method") === "get") ? "get" : "post";
     form.action = to;
     form.style.display = "hidden";
 


### PR DESCRIPTION
With this change, creating a button/link with `method: "get"` causes the generated form to issue a corresponding GET request.