### PR TITLE
Whitelist accepted URI schemes

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -66,6 +66,11 @@ defmodule Phoenix.HTML.Link do
       config :phoenix_html, csrf_token_generator: {MyGenerator, :get_token, []}
 
   """
+  @valid_uri_schemes ["http:", "https:", "ftp:", "ftps:", "mailto:",
+                      "news:", "irc:", "gopher:", "nntp:", "feed:",
+                      "telnet:", "mms:", "rtsp:", "svn:", "tel:", "fax:",
+                      "xmpp:"]
+
   def link(text, opts)
 
   def link(opts, do: contents) when is_list(opts) do
@@ -78,6 +83,11 @@ defmodule Phoenix.HTML.Link do
 
   def link(text, opts) do
     {to, opts} = pop_required_option!(opts, :to, "expected non-nil value for :to in link/2")
+
+    if invalid_destination?(to) do
+      raise ArgumentError, "link/2 expects a valid URL or path"
+    end
+
     {method, opts} = Keyword.pop(opts, :method, :get)
 
     if method == :get do
@@ -165,4 +175,11 @@ defmodule Phoenix.HTML.Link do
 
     {value, opts}
   end
+
+  defp invalid_destination?(to) when is_tuple(to), do: false
+
+  for scheme <- @valid_uri_schemes do
+    defp invalid_destination?(unquote(scheme) <> _), do: false
+  end
+  defp invalid_destination?(to), do: String.contains?(to, ":")
 end

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -84,7 +84,7 @@ defmodule Phoenix.HTML.Link do
   def link(text, opts) do
     {to, opts} = pop_required_option!(opts, :to, "expected non-nil value for :to in link/2")
 
-    to = valid_destination!(to)
+    to = valid_destination!(to, "link/2")
 
     {method, opts} = Keyword.pop(opts, :method, :get)
 
@@ -137,7 +137,7 @@ defmodule Phoenix.HTML.Link do
     {to, opts} = pop_required_option!(opts, :to, "option :to is required in button/2")
     {method, opts} = Keyword.pop(opts, :method, :post)
 
-    to = valid_destination!(to)
+    to = valid_destination!(to, "button/2")
 
     if method == :get do
       opts = skip_csrf(opts)
@@ -176,10 +176,10 @@ defmodule Phoenix.HTML.Link do
     {value, opts}
   end
 
-  defp valid_destination!(to) do
+  defp valid_destination!(to, calling_func) do
     if invalid_destination?(to) do
       raise ArgumentError, """
-      unsupported scheme given to link/2. In case you want to link to an
+      unsupported scheme given to #{calling_func}. In case you want to link to an
       unknown or unsafe scheme, such as javascript, use a tuple: {:javascript, rest}
       """
     end

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -185,7 +185,8 @@ defmodule Phoenix.HTML.Link do
     end
 
     case to do
-      {_, dest} -> dest
+      {:safe, _} = dest -> dest
+      {scheme, dest} -> "#{scheme}:#{dest}"
       dest -> dest
     end
   end
@@ -193,11 +194,8 @@ defmodule Phoenix.HTML.Link do
   for scheme <- @valid_uri_schemes do
     defp invalid_destination?(unquote(scheme) <> _), do: false
   end
-  defp invalid_destination?({:safe, to}) do
-    invalid_destination?(to)
-  end
   defp invalid_destination?({scheme, to}) when is_atom(scheme) do
-    !String.starts_with?(to, "#{scheme}:")
+    invalid_destination?(to)
   end
   defp invalid_destination?(to) when is_binary(to) do
     String.contains?(to, ":")

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -184,18 +184,21 @@ defmodule Phoenix.HTML.Link do
       """
     end
 
-    case to do
-      {:safe, _} = dest -> dest
-      {scheme, dest} -> "#{scheme}:#{dest}"
-      dest -> dest
-    end
+    valid_destination!(to)
   end
+  defp valid_destination!({:safe, to}) do
+    {:safe, valid_destination!(to)}
+  end
+  defp valid_destination!({other, to}) when is_atom(other) do
+    [Atom.to_string(other), ?:, to]
+  end
+  defp valid_destination!(to), do: to
 
   for scheme <- @valid_uri_schemes do
     defp invalid_destination?(unquote(scheme) <> _), do: false
   end
-  defp invalid_destination?({scheme, to}) when is_atom(scheme) do
-    invalid_destination?(to)
+  defp invalid_destination?({scheme, _}) when is_atom(scheme) do
+    false
   end
   defp invalid_destination?(to) when is_binary(to) do
     String.contains?(to, ":")

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -84,7 +84,7 @@ defmodule Phoenix.HTML.Link do
   def link(text, opts) do
     {to, opts} = pop_required_option!(opts, :to, "expected non-nil value for :to in link/2")
 
-    to = valid_destination(to)
+    to = valid_destination!(to)
 
     {method, opts} = Keyword.pop(opts, :method, :get)
 
@@ -137,7 +137,7 @@ defmodule Phoenix.HTML.Link do
     {to, opts} = pop_required_option!(opts, :to, "option :to is required in button/2")
     {method, opts} = Keyword.pop(opts, :method, :post)
 
-    to = valid_destination(to)
+    to = valid_destination!(to)
 
     if method == :get do
       opts = skip_csrf(opts)
@@ -176,7 +176,7 @@ defmodule Phoenix.HTML.Link do
     {value, opts}
   end
 
-  defp valid_destination(to) do
+  defp valid_destination!(to) do
     if invalid_destination?(to) do
       raise ArgumentError, """
       unsupported scheme given to link/2. In case you want to link to an

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -106,4 +106,14 @@ defmodule Phoenix.HTML.LinkTest do
     assert safe_to_string(button("hello", to: "/world", class: "btn rounded", id: "btn")) ==
            ~s[<button class="btn rounded" data-csrf="#{csrf_token}" data-method="post" data-to="/world" id="btn">hello</button>]
   end
+
+  test "button with invalid args" do
+    msg = """
+          unsupported scheme given to button/2. In case you want to link to an
+          unknown or unsafe scheme, such as javascript, use a tuple: {:javascript, rest}
+          """
+    assert_raise ArgumentError, msg, fn ->
+      button("foo", to: "javascript:alert(1)", method: :get)
+    end
+  end
 end

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -32,7 +32,7 @@ defmodule Phoenix.HTML.LinkTest do
   end
 
   test "link with scheme tuple" do
-    assert safe_to_string(link("foo", to: {:javascript, "javascript:alert(1)"})) ==
+    assert safe_to_string(link("foo", to: {:javascript, "alert(1)"})) ==
            ~s[<a href="javascript:alert(1)">foo</a>]
   end
 

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -46,6 +46,11 @@ defmodule Phoenix.HTML.LinkTest do
     assert_raise ArgumentError, msg, fn ->
       link(to: "/hello-world")
     end
+
+    msg = "link/2 expects a valid URL or path"
+    assert_raise ArgumentError, msg, fn ->
+      link("foo", to: "javascript:alert(1)")
+    end
   end
 
   test "button with post (default)" do

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -31,6 +31,11 @@ defmodule Phoenix.HTML.LinkTest do
     assert safe_to_string(link(to: "/hello", do: "world")) == ~s[<a href="/hello">world</a>]
   end
 
+  test "link with scheme tuple" do
+    assert safe_to_string(link("foo", to: {:javascript, "javascript:alert(1)"})) ==
+           ~s[<a href="javascript:alert(1)">foo</a>]
+  end
+
   test "link with invalid args" do
     msg = "expected non-nil value for :to in link/2"
     assert_raise ArgumentError, msg, fn ->
@@ -47,9 +52,21 @@ defmodule Phoenix.HTML.LinkTest do
       link(to: "/hello-world")
     end
 
-    msg = "link/2 expects a valid URL or path"
+    msg = """
+          unsupported scheme given to link/2. In case you want to link to an
+          unknown or unsafe scheme, such as javascript, use a tuple: {:javascript, rest}
+          """
     assert_raise ArgumentError, msg, fn ->
       link("foo", to: "javascript:alert(1)")
+    end
+
+    assert_raise ArgumentError, msg, fn ->
+      link("foo", to: {:bitcoin, "javascript:alert(1)"})
+    end
+
+    input = Phoenix.HTML.html_escape("javascript:alert(1)")
+    assert_raise ArgumentError, msg, fn ->
+      link("foo", to: input)
     end
   end
 

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -34,6 +34,12 @@ defmodule Phoenix.HTML.LinkTest do
   test "link with scheme tuple" do
     assert safe_to_string(link("foo", to: {:javascript, "alert(1)"})) ==
            ~s[<a href="javascript:alert(1)">foo</a>]
+
+    assert safe_to_string(link("foo", to: {:javascript, {:safe, "alert(1)"}})) ==
+           ~s[<a href="javascript:alert(1)">foo</a>]
+
+    assert safe_to_string(link("foo", to: {:safe, {:javascript, "alert(1)"}})) ==
+           ~s[<a href="javascript:alert(1)">foo</a>]
   end
 
   test "link with invalid args" do
@@ -58,15 +64,6 @@ defmodule Phoenix.HTML.LinkTest do
           """
     assert_raise ArgumentError, msg, fn ->
       link("foo", to: "javascript:alert(1)")
-    end
-
-    assert_raise ArgumentError, msg, fn ->
-      link("foo", to: {:bitcoin, "javascript:alert(1)"})
-    end
-
-    input = Phoenix.HTML.html_escape("javascript:alert(1)")
-    assert_raise ArgumentError, msg, fn ->
-      link("foo", to: input)
     end
   end
 


### PR DESCRIPTION
This is a PR to allow conversation to continue, but isn't yet complete. The current implementation only raises for "link", but I suspect we will also want to do so for "button"?  

I went with a [whitelist approach](https://security.stackexchange.com/questions/148428/which-url-schemes-are-dangerous-xss-exploitable). And I also added a start to the tuples allowing javascript or data URIs. It is currently only:

```
defp invalid_destination?(to) when is_tuple(to), do: false
```

Do we want to implement the functionality to transform `{:javascript, val}` within the `content_tag` function? Or do we want the `link` function to transform that value?

Edit:

I do think transforming w/in link could be nice, because that would allow us to clear the invalid URL instead of raising (which becomes a DoS as opposed to an XSS).

Something to the effect of...

```
...
to = dest(to)
...
for scheme <- @valid_uri_schemes do
  defp dest(unquote(scheme) <> _ = to), do: to
end
defp dest({scheme, to}) when is_atom(scheme) do
  if String.starts_with?(to, "#{scheme}:"), do: to
end
defp dest(to) when is_binary(to) do
  if !String.contains?(to, ":"), do: to
end
... 
```

