### PR TITLE
Add date, datetime-local and time input types

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -536,7 +536,12 @@ defmodule Phoenix.HTML.Form do
   See `text_input/3` for example and docs.
   """
   def datetime_local_input(form, field, opts \\ []) do
-    opts = Keyword.replace(opts, :value, datetime_local_input_value(Keyword.get(opts, :value)))
+    opts = case Keyword.fetch(opts, :value) do
+      {:ok, value} ->
+        Keyword.put(opts, :value, datetime_local_input_value(value))
+      :error ->
+        opts
+    end
     generic_input(:'datetime-local', form, field, opts)
   end
 
@@ -556,7 +561,12 @@ defmodule Phoenix.HTML.Form do
   See `text_input/3` for example and docs.
   """
   def time_input(form, field, opts \\ []) do
-    opts = Keyword.replace(opts, :value, time_input_value(Keyword.get(opts, :value)))
+    opts = case Keyword.fetch(opts, :value) do
+      {:ok, value} ->
+        Keyword.put(opts, :value, time_input_value(value))
+      :error ->
+        opts
+    end
     generic_input(:time, form, field, opts)
   end
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -540,9 +540,9 @@ defmodule Phoenix.HTML.Form do
     generic_input(:'datetime-local', form, field, opts)
   end
 
-  defp datetime_local_input_value(%{__struct__: NaiveDateTime} = value) do
-    str = to_string(value)
-    String.slice(str, 0..9) <> "T" <> String.slice(str, 11..15)
+  defp datetime_local_input_value(%NaiveDateTime{} = value) do
+    <<date::10-binary, ?\s, hour_minute::5-binary, _rest::binary>> = NaiveDateTime.to_string(value)
+    [date, ?T, hour_minute]
   end
 
   defp datetime_local_input_value(other), do: other
@@ -560,7 +560,7 @@ defmodule Phoenix.HTML.Form do
     generic_input(:time, form, field, opts)
   end
 
-  defp time_input_value(%{__struct__: Time} = value) do
+  defp time_input_value(%Time{} = value) do
     value
     |> to_string
     |> String.slice(0..4)

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -515,6 +515,42 @@ defmodule Phoenix.HTML.Form do
     generic_input(:range, form, field, opts)
   end
 
+  @doc """
+  Generates a date input.
+
+  Warning: this feature isn't available in all browsers.
+  Check `http://caniuse.com/#feat=input-datetime` for further informations.
+
+  See `text_input/3` for example and docs.
+  """
+  def date_input(form, field, opts \\ []) do
+    generic_input(:date, form, field, opts)
+  end
+
+  @doc """
+  Generates a datetime input.
+
+  Warning: this feature isn't available in all browsers.
+  Check `http://caniuse.com/#feat=input-datetime` for further informations.
+
+  See `text_input/3` for example and docs.
+  """
+  def datetime_input(form, field, opts \\ []) do
+    generic_input(:datetime, form, field, opts)
+  end
+
+  @doc """
+  Generates a time input.
+
+  Warning: this feature isn't available in all browsers.
+  Check `http://caniuse.com/#feat=input-datetime` for further informations.
+
+  See `text_input/3` for example and docs.
+  """
+  def time_input(form, field, opts \\ []) do
+    generic_input(:time, form, field, opts)
+  end
+
   defp generic_input(type, form, field, opts) when is_atom(field) and is_list(opts) do
     opts =
       opts

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -535,8 +535,8 @@ defmodule Phoenix.HTML.Form do
 
   See `text_input/3` for example and docs.
   """
-  def datetime_input(form, field, opts \\ []) do
-    generic_input(:datetime, form, field, opts)
+  def datetime_local_input(form, field, opts \\ []) do
+    generic_input(:'datetime-local', form, field, opts)
   end
 
   @doc """

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -536,8 +536,16 @@ defmodule Phoenix.HTML.Form do
   See `text_input/3` for example and docs.
   """
   def datetime_local_input(form, field, opts \\ []) do
+    opts = Keyword.replace(opts, :value, datetime_local_input_value(Keyword.get(opts, :value)))
     generic_input(:'datetime-local', form, field, opts)
   end
+
+  defp datetime_local_input_value(%{__struct__: NaiveDateTime} = value) do
+    str = to_string(value)
+    String.slice(str, 0..9) <> "T" <> String.slice(str, 11..15)
+  end
+
+  defp datetime_local_input_value(other), do: other
 
   @doc """
   Generates a time input.
@@ -548,8 +556,17 @@ defmodule Phoenix.HTML.Form do
   See `text_input/3` for example and docs.
   """
   def time_input(form, field, opts \\ []) do
+    opts = Keyword.replace(opts, :value, time_input_value(Keyword.get(opts, :value)))
     generic_input(:time, form, field, opts)
   end
+
+  defp time_input_value(%{__struct__: Time} = value) do
+    value
+    |> to_string
+    |> String.slice(0..4)
+  end
+
+  defp time_input_value(other), do: other
 
   defp generic_input(type, form, field, opts) when is_atom(field) and is_list(opts) do
     opts =

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -528,7 +528,7 @@ defmodule Phoenix.HTML.Form do
   end
 
   @doc """
-  Generates a datetime input.
+  Generates a datetime-local input.
 
   Warning: this feature isn't available in all browsers.
   Check `http://caniuse.com/#feat=input-datetime` for further informations.

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -300,7 +300,7 @@ defmodule Phoenix.HTML.FormTest do
           ~s(<input id="key" name="search[key][]" type="tel" value="foo">)
   end
 
-  ## range_input/3
+  ## date_input/3
 
   test "range_input/3" do
     assert safe_to_string(range_input(:search, :key)) ==
@@ -316,6 +316,60 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_form(&range_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="range" value="foo">)
+  end
+
+  ## date_input/3
+
+  test "date_input/3" do
+    assert safe_to_string(date_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="date">)
+
+    assert safe_to_string(date_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="date" value="foo">)
+  end
+
+  test "date_input/3 with form" do
+    assert safe_form(&date_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="date" value="value">)
+
+    assert safe_form(&date_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="date" value="foo">)
+  end
+
+  ## datetime_input/3
+
+  test "datetime_input/3" do
+    assert safe_to_string(datetime_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime">)
+
+    assert safe_to_string(datetime_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+  end
+
+  test "datetime_input/3 with form" do
+    assert safe_form(&datetime_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime" value="value">)
+
+    assert safe_form(&datetime_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+  end
+
+  ## time_input/3
+
+  test "time_input/3" do
+    assert safe_to_string(time_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="time">)
+
+    assert safe_to_string(time_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="time" value="foo">)
+  end
+
+  test "time_input/3 with form" do
+    assert safe_form(&time_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="time" value="value">)
+
+    assert safe_form(&time_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="time" value="foo">)
   end
 
   ## submit/2

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -300,7 +300,7 @@ defmodule Phoenix.HTML.FormTest do
           ~s(<input id="key" name="search[key][]" type="tel" value="foo">)
   end
 
-  ## date_input/3
+  ## range_input/3
 
   test "range_input/3" do
     assert safe_to_string(range_input(:search, :key)) ==

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -342,7 +342,7 @@ defmodule Phoenix.HTML.FormTest do
           ~s(<input id="key" name="search[key][]" type="date" value="2017-09-21">)
   end
 
-  ## datetime_local_input/3
+  ## datetime_input/3
 
   test "datetime_local_input/3" do
     assert safe_to_string(datetime_local_input(:search, :key)) ==

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -338,20 +338,20 @@ defmodule Phoenix.HTML.FormTest do
 
   ## datetime_input/3
 
-  test "datetime_input/3" do
-    assert safe_to_string(datetime_input(:search, :key)) ==
-          ~s(<input id="search_key" name="search[key]" type="datetime">)
+  test "datetime_local_input/3" do
+    assert safe_to_string(datetime_local_input(:search, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime-local">)
 
-    assert safe_to_string(datetime_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
-          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+    assert safe_to_string(datetime_local_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)
   end
 
-  test "datetime_input/3 with form" do
-    assert safe_form(&datetime_input(&1, :key)) ==
-          ~s(<input id="search_key" name="search[key]" type="datetime" value="value">)
+  test "datetime_local_input/3 with form" do
+    assert safe_form(&datetime_local_input(&1, :key)) ==
+          ~s(<input id="search_key" name="search[key]" type="datetime-local" value="value">)
 
-    assert safe_form(&datetime_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
-          ~s(<input id="key" name="search[key][]" type="datetime" value="foo">)
+    assert safe_form(&datetime_local_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)
   end
 
   ## time_input/3

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -326,6 +326,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(date_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="date" value="foo">)
+
+    assert safe_to_string(date_input(:search, :key, value: ~D[2017-09-21], id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="date" value="2017-09-21">)
   end
 
   test "date_input/3 with form" do
@@ -334,9 +337,12 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_form(&date_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="date" value="foo">)
+
+    assert safe_form(&date_input(&1, :key, value: ~D[2017-09-21], id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="date" value="2017-09-21">)
   end
 
-  ## datetime_input/3
+  ## datetime_local_input/3
 
   test "datetime_local_input/3" do
     assert safe_to_string(datetime_local_input(:search, :key)) ==
@@ -344,6 +350,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(datetime_local_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)
+
+    assert safe_to_string(datetime_local_input(:search, :key, value: ~N[2017-09-21 20:21:53], id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime-local" value="2017-09-21T20:21">)
   end
 
   test "datetime_local_input/3 with form" do
@@ -352,6 +361,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_form(&datetime_local_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)
+
+    assert safe_form(&datetime_local_input(&1, :key, value: ~N[2017-09-21 20:21:53], id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="datetime-local" value="2017-09-21T20:21">)
   end
 
   ## time_input/3
@@ -362,6 +374,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(time_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="time" value="foo">)
+
+    assert safe_to_string(time_input(:search, :key, value: ~T[23:00:07.001], id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="time" value="23:00">)
   end
 
   test "time_input/3 with form" do
@@ -370,6 +385,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_form(&time_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
           ~s(<input id="key" name="search[key][]" type="time" value="foo">)
+
+    assert safe_form(&time_input(&1, :key, value: ~T[23:00:07.001], id: "key", name: "search[key][]")) ==
+          ~s(<input id="key" name="search[key][]" type="time" value="23:00">)
   end
 
   ## submit/2


### PR DESCRIPTION
Continuation of #142. Addresses some of the feedback @josevalim gave there:

* Tests added for `Date`, `NaiveDateTime`, and `Time` values passed to `*_input` functions
* Conversion of these values to valid strings following MDN [date](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date), [datetime-local](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local), and [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time) specs

I'm not sure about the input value conversion code, feels a bit clumsy still, but it makes the tests pass, which was my first concern. I'm still fairly new to Elixir, feedback on code style is much appreciated here!

Feedback not (yet) addressed:

* Decided not to rename `datetime_local_input` to `naive_datetime_input`. Felt inconsistent to name this input after the _Elixir_ construct, where all other input tag methods have been named after their _HTML_ types.
* I'm not sure I understand what's needed to fulfill @josevalim 's request to "standardize around Elixir's calendar types". I possible, please provide some guidance (docs, articles, anything) and I'll try to work it out 😄 



 