### PR TITLE
Escape value of form input tags

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -585,8 +585,12 @@ defmodule Phoenix.HTML.Form do
       |> Keyword.put_new(:id, input_id(form, field))
       |> Keyword.put_new(:name, input_name(form, field))
       |> Keyword.put_new(:value, input_value(form, field))
+      |> Keyword.update(:value, nil, &escape_value/1)
     tag(:input, opts)
   end
+
+  defp escape_value(nil), do: nil
+  defp escape_value(value), do: html_escape(value)
 
   @doc """
   Generates a textarea input.

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -160,6 +160,12 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(hidden_input(:search, :key, value: "foo", id: "key", name: "search[key][]")) ==
            ~s(<input id="key" name="search[key][]" type="hidden" value="foo">)
+
+    assert safe_to_string(hidden_input(:search, :key, value: true, id: "key", name: "search[key][]")) ==
+           ~s(<input id="key" name="search[key][]" type="hidden" value="true">)
+
+    assert safe_to_string(hidden_input(:search, :key, value: false, id: "key", name: "search[key][]")) ==
+           ~s(<input id="key" name="search[key][]" type="hidden" value="false">)
   end
 
   test "hidden_input/3 with form" do


### PR DESCRIPTION
This PR addresses issue #171, which I have experienced myself yesterday.

This pull request escapes the value option of form inputs to ensure that it gets represented properly in the generated HTML.

The HTML semantics of representing true attributes by repeating the key in the value (such as `disabled="disabled"`) cause some confusion on the value attribute, which would be represented as `value="value"` instead of `value="true"`.
