### PR TITLE
fix bug with unicode characters in escape_javascript/1 and safe_to_string/1

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -155,10 +155,19 @@ defmodule Phoenix.HTML do
 
   Fails if the result is not safe. In such cases, you can
   invoke `html_escape/1` or `raw/1` accordingly before.
+
+      iex> safe_to_string({:safe, ["o", 'k']})
+      "ok"
+
+      iex> safe_to_string({:safe, 'ünicode'})
+      "ünicode"
+
+      iex> safe_to_string("unsafe")
+      ** (FunctionClauseError) no function clause matching in Phoenix.HTML.safe_to_string/1
   """
   @spec safe_to_string(safe) :: String.t
   def safe_to_string({:safe, iodata}) do
-    IO.iodata_to_binary(iodata)
+    IO.chardata_to_string(iodata)
   end
 
   @doc """

--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -159,9 +159,6 @@ defmodule Phoenix.HTML do
       iex> safe_to_string({:safe, ["o", 'k']})
       "ok"
 
-      iex> safe_to_string({:safe, 'ünicode'})
-      "ünicode"
-
       iex> safe_to_string("unsafe")
       ** (FunctionClauseError) no function clause matching in Phoenix.HTML.safe_to_string/1
   """

--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -177,7 +177,7 @@ defmodule Phoenix.HTML do
   """
   @spec escape_javascript(binary | safe) :: String.t
   def escape_javascript({:safe, data}) do
-    {:safe, data |> IO.iodata_to_binary |> escape_javascript}
+    {:safe, data |> IO.chardata_to_string |> escape_javascript}
   end
 
   def escape_javascript(data) when is_binary(data) do

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -25,6 +25,10 @@ defmodule Phoenix.HTMLTest do
     assert escape_javascript({:safe, ["'Single quote'"]}) == {:safe, "\\'Single quote\\'"}
   end
 
+  test "safe_to_string/1" do
+    assert safe_to_string({:safe, 'ünicode'}) == "ünicode"
+  end
+
   test "only accepts valid iodata" do
     assert Phoenix.HTML.Safe.to_iodata("foo") == "foo"
     assert Phoenix.HTML.Safe.to_iodata('foo') == 'foo'

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -23,6 +23,7 @@ defmodule Phoenix.HTMLTest do
     assert escape_javascript(<<0x2029::utf8>>) == "&#x2029;"
     assert escape_javascript({:safe, "'Single quote'"}) == {:safe, "\\'Single quote\\'"}
     assert escape_javascript({:safe, ["'Single quote'"]}) == {:safe, "\\'Single quote\\'"}
+    assert escape_javascript({:safe, 'ünicode'}) == {:safe, "ünicode"}
   end
 
   test "safe_to_string/1" do


### PR DESCRIPTION
I'm assuming that these functions should be able to handle unicode characters. Thanks!