### PR TITLE
No longer require the :as option.

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -325,6 +325,8 @@ defmodule Phoenix.HTML.Form do
   The form should either be a `Phoenix.HTML.Form` emitted
   by `form_for` or an atom.
   """
+  def input_id(%{id: nil}, _field),
+    do: nil
   def input_id(%{id: id}, field),
     do: "#{id}_#{field}"
   def input_id(name, field) when is_atom(name),
@@ -336,6 +338,8 @@ defmodule Phoenix.HTML.Form do
   The form should either be a `Phoenix.HTML.Form` emitted
   by `form_for` or an atom.
   """
+  def input_name(%{name: nil}, field),
+    do: field
   def input_name(%{name: name}, field),
     do: "#{name}[#{field}]"
   def input_name(name, field) when is_atom(name),

--- a/lib/phoenix_html/form_data.ex
+++ b/lib/phoenix_html/form_data.ex
@@ -56,7 +56,7 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
 
         {name, opts} ->
           name = to_string(name || warn_name(opts))
-          {name, Map.get(conn.params, name), opts}
+          {name, Map.get(conn.params, name) || %{}, opts}
       end
 
     %Phoenix.HTML.Form{

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -79,6 +79,14 @@ defmodule Phoenix.HTML.FormTest do
     assert form =~ "<form"
   end
 
+  test "form_for/3 with no name" do
+    form = safe_to_string form_for(conn(), "/", fn f ->
+      text_input(f, :key)
+    end)
+
+    assert form =~ ~s(<input name="key" type="text">)
+  end
+
   ## text_input/3
 
   test "text_input/3" do


### PR DESCRIPTION
Sometimes users need a way to create a
form that does not wrap params inside a
named param. This commit removes the
:as requirement. Forms without the :as option
will no longer have an id generated and the form
inputs will also forgo automatic id generation.