### PR TITLE
Support carriage return in text_to_html

### DIFF
--- a/lib/phoenix_html/format.ex
+++ b/lib/phoenix_html/format.ex
@@ -39,6 +39,7 @@ defmodule Phoenix.HTML.Format do
 
     string
     |> maybe_html_escape(escape?)
+    |> String.replace("\r", "")
     |> String.split("\n\n", trim: true)
     |> Enum.filter(&not_blank?/1)
     |> Enum.map(&wrap_paragraph(&1, wrapper_tag, attributes, insert_brs?))

--- a/lib/phoenix_html/format.ex
+++ b/lib/phoenix_html/format.ex
@@ -6,9 +6,9 @@ defmodule Phoenix.HTML.Format do
   @doc ~S"""
   Returns text transformed into HTML using simple formatting rules.
 
-  Two or more consecutive newlines `\n\n` are considered as a paragraph
-  and text between them is wrapped in `<p>` tags.
-  One newline `\n` is considered as a linebreak and a `<br>` tag is inserted.
+  Two or more consecutive newlines `\n\n` or `\r\n\r\n` are considered as a
+  paragraph and text between them is wrapped in `<p>` tags.
+  One newline `\n` or `\r\n` is considered as a linebreak and a `<br>` tag is inserted.
 
   ## Examples
 
@@ -39,8 +39,7 @@ defmodule Phoenix.HTML.Format do
 
     string
     |> maybe_html_escape(escape?)
-    |> String.replace("\r", "")
-    |> String.split("\n\n", trim: true)
+    |> String.split(["\n\n", "\r\n\r\n"], trim: true)
     |> Enum.filter(&not_blank?/1)
     |> Enum.map(&wrap_paragraph(&1, wrapper_tag, attributes, insert_brs?))
     |> Phoenix.HTML.html_escape
@@ -49,10 +48,11 @@ defmodule Phoenix.HTML.Format do
   defp maybe_html_escape(string, true),  do: Plug.HTML.html_escape(string)
   defp maybe_html_escape(string, false), do: string
 
-  defp not_blank?(" " <> rest),  do: not_blank?(rest)
-  defp not_blank?("\n" <> rest), do: not_blank?(rest)
-  defp not_blank?(""),           do: false
-  defp not_blank?(_),            do: true
+  defp not_blank?("\r\n" <> rest), do: not_blank?(rest)
+  defp not_blank?("\n" <> rest),   do: not_blank?(rest)
+  defp not_blank?(" " <> rest),    do: not_blank?(rest)
+  defp not_blank?(""),             do: false
+  defp not_blank?(_),              do: true
 
   defp wrap_paragraph(text, tag, attributes, insert_brs?) do
     [Phoenix.HTML.Tag.content_tag(tag, insert_brs(text, insert_brs?), attributes), ?\n]
@@ -60,15 +60,19 @@ defmodule Phoenix.HTML.Format do
 
   defp insert_brs(text, false) do
     text
-    |> String.split("\n", trim: true)
+    |> split_lines()
     |> Enum.intersperse(?\s)
     |> Phoenix.HTML.raw
   end
 
   defp insert_brs(text, true) do
     text
-    |> String.split("\n", trim: true)
+    |> split_lines()
     |> Enum.map(&Phoenix.HTML.raw/1)
     |> Enum.intersperse([Phoenix.HTML.Tag.tag(:br), ?\n])
+  end
+
+  defp split_lines(text) do
+    String.split(text, ["\n", "\r\n"], trim: true)
   end
 end

--- a/test/phoenix_html/format_test.exs
+++ b/test/phoenix_html/format_test.exs
@@ -11,8 +11,8 @@ defmodule Phoenix.HTML.FormatTest do
       format("""
       Hello,
 
-      Please come see me.
-
+      Please come see me.\r
+      \r
       Regards,
       The boss.
       """)
@@ -51,7 +51,7 @@ defmodule Phoenix.HTML.FormatTest do
     formatted =
       format("""
       Hello,
-      This is dog,
+      This is dog,\r
       How can I help you?
 
 
@@ -68,7 +68,7 @@ defmodule Phoenix.HTML.FormatTest do
     formatted =
       format("""
       Hello,
-      This is dog,
+      This is dog,\r
       How can I help you?
 
 

--- a/test/phoenix_html/format_test.exs
+++ b/test/phoenix_html/format_test.exs
@@ -11,18 +11,30 @@ defmodule Phoenix.HTML.FormatTest do
       format("""
       Hello,
 
-      Please come see me.\r
-      \r
+      Please come see me.
+
       Regards,
-      The boss.
+      The Boss.
       """)
 
     assert formatted == """
     <p>Hello,</p>
     <p>Please come see me.</p>
     <p>Regards,<br>
-    The boss.</p>
+    The Boss.</p>
     """
+  end
+
+  test "wraps paragraphs with carriage returns" do
+    formatted =
+      format("Hello,\r\n\r\nPlease come see me.\r\n\r\nRegards,\r\nThe Boss.")
+
+    assert formatted == """
+      <p>Hello,</p>
+      <p>Please come see me.</p>
+      <p>Regards,<br>
+      The Boss.</p>
+      """
   end
 
   test "escapes html" do
@@ -51,7 +63,7 @@ defmodule Phoenix.HTML.FormatTest do
     formatted =
       format("""
       Hello,
-      This is dog,\r
+      This is dog,
       How can I help you?
 
 
@@ -64,11 +76,22 @@ defmodule Phoenix.HTML.FormatTest do
     """
   end
 
+  test "adds brs with carriage return" do
+    formatted =
+      format("Hello,\r\nThis is dog,\r\nHow can I help you?\r\n\r\n\r\n")
+
+    assert formatted == """
+    <p>Hello,<br>
+    This is dog,<br>
+    How can I help you?</p>
+    """
+  end
+
   test "doesnt add brs" do
     formatted =
       format("""
       Hello,
-      This is dog,\r
+      This is dog,
       How can I help you?
 
 


### PR DESCRIPTION
resolves #190

This PR adds support for `\r\n` (Carriage Return & Line Feed) in [`text_to_html/2`](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Format.html#text_to_html/2).