### PR TITLE
JS escape fixes for uncommon whitespace and null

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -182,6 +182,8 @@ defmodule Phoenix.HTML do
     do: escape_javascript(t, <<acc::binary, "\\u2028">>)
   defp escape_javascript(<<0x2029::utf8, t::binary>>, acc),
     do: escape_javascript(t, <<acc::binary, "\\u2029">>)
+  defp escape_javascript(<<0::utf8, t::binary>>, acc),
+    do: escape_javascript(t, <<acc::binary, "\\u0000">>)
   defp escape_javascript(<<"</", t::binary>>, acc),
     do: escape_javascript(t, <<acc::binary, ?<, ?\\, ?/>>)
   defp escape_javascript(<<"\r\n", t::binary>>, acc),

--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -179,9 +179,9 @@ defmodule Phoenix.HTML do
   end
 
   defp escape_javascript(<<0x2028::utf8, t::binary>>, acc),
-    do: escape_javascript(t, <<acc::binary, "&#x2028;">>)
+    do: escape_javascript(t, <<acc::binary, "\\u2028">>)
   defp escape_javascript(<<0x2029::utf8, t::binary>>, acc),
-    do: escape_javascript(t, <<acc::binary, "&#x2029;">>)
+    do: escape_javascript(t, <<acc::binary, "\\u2029">>)
   defp escape_javascript(<<"</", t::binary>>, acc),
     do: escape_javascript(t, <<acc::binary, ?<, ?\\, ?/>>)
   defp escape_javascript(<<"\r\n", t::binary>>, acc),

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -19,8 +19,8 @@ defmodule Phoenix.HTMLTest do
     assert escape_javascript("New line\n") == "New line\\n"
     assert escape_javascript("New line\r\n") == "New line\\n"
     assert escape_javascript("</close>") == "<\\/close>"
-    assert escape_javascript(<<0x2028::utf8>>) == "&#x2028;"
-    assert escape_javascript(<<0x2029::utf8>>) == "&#x2029;"
+    assert escape_javascript("Line separator\u2028") == "Line separator\\u2028"
+    assert escape_javascript("Paragraph separator\u2029") == "Paragraph separator\\u2029"
     assert escape_javascript({:safe, "'Single quote'"}) == {:safe, "\\'Single quote\\'"}
     assert escape_javascript({:safe, ["'Single quote'"]}) == {:safe, "\\'Single quote\\'"}
   end

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -21,6 +21,7 @@ defmodule Phoenix.HTMLTest do
     assert escape_javascript("</close>") == "<\\/close>"
     assert escape_javascript("Line separator\u2028") == "Line separator\\u2028"
     assert escape_javascript("Paragraph separator\u2029") == "Paragraph separator\\u2029"
+    assert escape_javascript("Null character\u0000") == "Null character\\u0000"
     assert escape_javascript({:safe, "'Single quote'"}) == {:safe, "\\'Single quote\\'"}
     assert escape_javascript({:safe, ["'Single quote'"]}) == {:safe, "\\'Single quote\\'"}
   end


### PR DESCRIPTION
U+2028 and U+2029 is currently escaped using html escape sequences instead of js escapes, which this PR changes.

It also adds an escape for the U+0000 null character, which is invalid within html script tags.