### PR TITLE
Fixing id generation on radio buttons. fixes #194

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -333,6 +333,16 @@ defmodule Phoenix.HTML.Form do
   def input_id(name, field) when is_atom(name),
     do: "#{name}_#{field}"
 
+
+  @doc """
+  Returns an id of a corresponding form field and value attached to it.
+  Useful for radio buttons and inputs like multiselect checkboxes.
+  """
+  def input_id(name, field, value) do
+    value_id = String.replace(value, ~r/\W/u, "_")
+    input_id(name, field) <> "_" <> value_id
+  end
+
   @doc """
   Returns a name of a corresponding form field.
 
@@ -733,7 +743,7 @@ defmodule Phoenix.HTML.Form do
     opts =
       opts
       |> Keyword.put_new(:type, "radio")
-      |> Keyword.put_new(:id, input_id(form, field) <> "_" <> elem(value, 1))
+      |> Keyword.put_new(:id, input_id(form, field, elem(value, 1)))
       |> Keyword.put_new(:name, input_name(form, field))
 
     opts =

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -450,6 +450,9 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(radio_button(:search, :key, "admin", checked: true)) ==
           ~s(<input id="search_key_admin" name="search[key]" type="radio" value="admin" checked>)
+
+    assert safe_to_string(radio_button(:search, :key, "value with spaces")) ==
+          ~s(<input id="search_key_value_with_spaces" name="search[key]" type="radio" value="value with spaces">)
   end
 
   test "radio_button/4 with form" do
@@ -1004,6 +1007,16 @@ defmodule Phoenix.HTML.FormTest do
 
   test "input_id/2 with form" do
     assert safe_form(&input_id(&1, :key)) == "search_key"
+  end
+
+  ## input_id/3
+
+  test "input_id/3" do
+    assert input_id(:search, :key, "") == "search_key_"
+    assert input_id(:search, :key, "foo") == "search_key_foo"
+    assert input_id(:search, :key, "foo bar") == "search_key_foo_bar"
+    assert input_id(:search, :key, "Foo baR") == "search_key_Foo_baR"
+    assert input_id(:search, :key, "F✓o]o%b+a'R") == "search_key_F_o_o_b_a_R"
   end
 
   ## input_name/2


### PR DESCRIPTION
Made a `input_id/3` just so it's easier to generate `for` attribute on labels. Maybe it makes sense to expand `label` to allow value passing. Not sure. One thing at the time.