### PR TITLE
Enable string keys to be usable with forms

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -312,7 +312,7 @@ defmodule Phoenix.HTML.Form do
       impl.input_value(source, form, field)
     rescue
       UndefinedFunctionError ->
-        case Map.fetch(form.params, to_string(field)) do
+        case Map.fetch(form.params, field_to_string(field)) do
           {:ok, value} ->
             value
           :error ->
@@ -413,7 +413,7 @@ defmodule Phoenix.HTML.Form do
       end
 
     if type == :text_input do
-      field = to_string(field)
+      field = field_to_string(field)
       Enum.find_value(mapping, type, fn {k, v} ->
         String.contains?(field, k) && v
       end)
@@ -940,7 +940,7 @@ defmodule Phoenix.HTML.Form do
     if value != nil do
       {value, opts}
     else
-      param = to_string(field)
+      param = field_to_string(field)
 
       case form do
         %{params: %{^param => sent}} ->
@@ -1397,6 +1397,10 @@ defmodule Phoenix.HTML.Form do
     opts = Keyword.put_new(opts, :for, input_id(form, field))
     content_tag(:label, opts, do: block)
   end
+
+  # Normalize field name to string version
+  defp field_to_string(field) when is_atom(field), do: Atom.to_string(field)
+  defp field_to_string(field) when is_binary(field), do: field
 
   # TODO: Remove me on 3.0
 

--- a/lib/phoenix_html/form_data.ex
+++ b/lib/phoenix_html/form_data.ex
@@ -23,27 +23,27 @@ defprotocol Phoenix.HTML.FormData do
   and it must be stored in the underlying struct, with any
   custom field removed.
   """
-  @spec to_form(t, Phoenix.HTML.Form.t, atom | String.t, Keyword.t) :: Phoenix.HTML.Form.t
+  @spec to_form(t, Phoenix.HTML.Form.t, Phoenix.HTML.Form.field, Keyword.t) :: Phoenix.HTML.Form.t
   def to_form(data, form, field, options)
 
   @doc """
   Returns the value for the given field.
   """
-  @spec input_value(t, Phoenix.HTML.Form.t, atom | String.t) :: term
+  @spec input_value(t, Phoenix.HTML.Form.t, Phoenix.HTML.Form.field) :: term
   def input_value(data, form, field)
 
   @doc """
   Returns the HTML5 validations that would apply to
   the given field.
   """
-  @spec input_validations(t, Phoenix.HTML.Form.t, atom | String.t) :: Keyword.t
+  @spec input_validations(t, Phoenix.HTML.Form.t, Phoenix.HTML.Form.field) :: Keyword.t
   def input_validations(data, form, field)
 
   @doc """
   Receives the given field and returns its input type (:text_input,
   :select, etc). Returns `nil` if the type is unknown.
   """
-  @spec input_type(t, Phoenix.HTML.Form.t, atom | String.t) :: atom | nil
+  @spec input_type(t, Phoenix.HTML.Form.t, Phoenix.HTML.Form.field) :: atom | nil
   def input_type(data, form, field)
 end
 
@@ -70,7 +70,7 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
     }
   end
 
-  def to_form(conn, form, field, opts) do
+  def to_form(conn, form, field, opts) when is_atom(field) or is_binary(field) do
     {default, opts} = Keyword.pop(opts, :default, %{})
     {prepend, opts} = Keyword.pop(opts, :prepend, [])
     {append, opts}  = Keyword.pop(opts, :append, [])
@@ -119,7 +119,7 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
     end
   end
 
-  def input_value(_conn, %{data: data, params: params}, field) do
+  def input_value(_conn, %{data: data, params: params}, field) when is_atom(field) or is_binary(field) do
     case Map.fetch(params, to_string(field)) do
       {:ok, value} ->
         value

--- a/lib/phoenix_html/form_data.ex
+++ b/lib/phoenix_html/form_data.ex
@@ -23,27 +23,27 @@ defprotocol Phoenix.HTML.FormData do
   and it must be stored in the underlying struct, with any
   custom field removed.
   """
-  @spec to_form(t, Phoenix.HTML.Form.t, atom, Keyword.t) :: Phoenix.HTML.Form.t
+  @spec to_form(t, Phoenix.HTML.Form.t, atom | String.t, Keyword.t) :: Phoenix.HTML.Form.t
   def to_form(data, form, field, options)
 
   @doc """
   Returns the value for the given field.
   """
-  @spec input_value(t, Phoenix.HTML.Form.t, atom) :: term
+  @spec input_value(t, Phoenix.HTML.Form.t, atom | String.t) :: term
   def input_value(data, form, field)
 
   @doc """
   Returns the HTML5 validations that would apply to
   the given field.
   """
-  @spec input_validations(t, Phoenix.HTML.Form.t, atom) :: Keyword.t
+  @spec input_validations(t, Phoenix.HTML.Form.t, atom | String.t) :: Keyword.t
   def input_validations(data, form, field)
 
   @doc """
   Receives the given field and returns its input type (:text_input,
   :select, etc). Returns `nil` if the type is unknown.
   """
-  @spec input_type(t, Phoenix.HTML.Form.t, atom) :: atom | nil
+  @spec input_type(t, Phoenix.HTML.Form.t, atom | String.t) :: atom | nil
   def input_type(data, form, field)
 end
 
@@ -79,7 +79,7 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
 
     id     = to_string(id || form.id <> "_#{field}")
     name   = to_string(name || form.name <> "[#{field}]")
-    params = Map.get(form.params, Atom.to_string(field))
+    params = Map.get(form.params, to_string(field))
 
     cond do
       # cardinality: one
@@ -120,7 +120,7 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
   end
 
   def input_value(_conn, %{data: data, params: params}, field) do
-    case Map.fetch(params, Atom.to_string(field)) do
+    case Map.fetch(params, to_string(field)) do
       {:ok, value} ->
         value
       :error ->

--- a/lib/phoenix_html/form_data.ex
+++ b/lib/phoenix_html/form_data.ex
@@ -79,7 +79,7 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
 
     id     = to_string(id || form.id <> "_#{field}")
     name   = to_string(name || form.name <> "[#{field}]")
-    params = Map.get(form.params, to_string(field))
+    params = Map.get(form.params, field_to_string(field))
 
     cond do
       # cardinality: one
@@ -120,7 +120,7 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
   end
 
   def input_value(_conn, %{data: data, params: params}, field) when is_atom(field) or is_binary(field) do
-    case Map.fetch(params, to_string(field)) do
+    case Map.fetch(params, field_to_string(field)) do
       {:ok, value} ->
         value
       :error ->
@@ -130,4 +130,8 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
 
   def input_type(_conn, _form, _field), do: :text_input
   def input_validations(_conn, _form, _field), do: []
+
+  # Normalize field name to string version
+  defp field_to_string(field) when is_atom(field), do: Atom.to_string(field)
+  defp field_to_string(field) when is_binary(field), do: field
 end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -991,6 +991,7 @@ defmodule Phoenix.HTML.FormTest do
 
   test "input_value/2 with form" do
     assert safe_form(&input_value(&1, :key)) == "value"
+    assert safe_form(&input_value(&1, "key")) == "value"
   end
 
   test "input_value/2 with form and data" do
@@ -998,6 +999,12 @@ defmodule Phoenix.HTML.FormTest do
     assert safe_form(&input_value(put_in(&1.data[:no_key], "original"), :no_key)) == "original"
     safe_form(fn f ->
         assert input_value(put_in(f.data[:alt_key], "original"), :alt_key) == nil
+        ""
+    end)
+    assert safe_form(&input_value(put_in(&1.data["key"], "original"), "key")) == "value"
+    assert safe_form(&input_value(put_in(&1.data["no_key"], "original"), "no_key")) == "original"
+    safe_form(fn f ->
+        assert input_value(put_in(f.data["alt_key"], "original"), "alt_key") == nil
         ""
     end)
   end


### PR DESCRIPTION
Seems like `input_value` / FormData implementations were the only thing really relying on atom keys. The rest were either using `input_value` or doing `Atom.to_string` anyways.

I'd expect this would need `phoenix_ecto` to be updated as well.

Regarding to #197 