### PR TITLE
input_name should return a String when passed an unnamed form.

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -361,7 +361,7 @@ defmodule Phoenix.HTML.Form do
   """
   @spec input_name(t | atom, field) :: String.t
   def input_name(%{name: nil}, field),
-    do: field
+    do: to_string(field)
   def input_name(%{name: name}, field) when is_atom(field) or is_binary(field),
     do: "#{name}[#{field}]"
   def input_name(name, field) when is_atom(name) and is_atom(field) or is_binary(field),


### PR DESCRIPTION
- This bug shows up when using multiple_select with an unnamed form.
- Function spec indicates that input_name returns a String.