### PR TITLE
JS : use the target attribute of the link on the generated form

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -18,11 +18,14 @@
     var to = link.getAttribute("data-to"),
         method = buildHiddenInput("_method", link.getAttribute("data-method")),
         csrf = buildHiddenInput("_csrf_token", link.getAttribute("data-csrf")),
-        form = document.createElement("form");
+        form = document.createElement("form"),
+        target = link.getAttribute("target");
 
     form.method = (link.getAttribute("data-method") === "get") ? "get" : "post";
     form.action = to;
     form.style.display = "hidden";
+
+    if (target) form.target = target;
 
     form.appendChild(csrf);
     form.appendChild(method);


### PR DESCRIPTION
When creating a link with the `link` Phoenix helper, I would expect the `target` attribute to work seamlessly with any HTTP method.

Right now the `target` attribute only works with the GET method because it's not passed to the generated form when using another method.

I'm working on an admin area in Phoenix where I need to call an action with POST and would like to open the result in a new tab using `target: "_blank"`, this small change allows me to do that and I now get the same `target` behaviour for any HTTP method...

Thanks!
