### PR TITLE
Allow value option on labels for easier building of dynamic radio buttons/checkboxes

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1433,6 +1433,9 @@ defmodule Phoenix.HTML.Form do
         "E-mail Address"
       end
       #=> <label class="control-label" for="user_email">E-mail Address</label>
+
+      label :user, :newsletters, "Recieve all newsletters", value: "all"
+      #=> <label for="user_newsletters_all">Recieve all newsletters</label>
   """
   def label(form, field) do
     label(form, field, humanize(field), [])
@@ -1457,12 +1460,22 @@ defmodule Phoenix.HTML.Form do
   See `label/2`.
   """
   def label(form, field, text, opts) when is_binary(text) and is_list(opts) do
-    opts = Keyword.put_new(opts, :for, input_id(form, field))
+    {opts, input_id} = case Keyword.pop(opts, :value) do
+      {nil, opts} -> {opts, input_id(form, field)}
+      {value, opts} -> {opts, input_id(form, field, value)}
+    end
+
+    opts = Keyword.put_new(opts, :for, input_id)
     content_tag(:label, text, opts)
   end
 
   def label(form, field, opts, do: block) do
-    opts = Keyword.put_new(opts, :for, input_id(form, field))
+    {opts, input_id} = case Keyword.pop(opts, :value) do
+      {nil, opts} -> {opts, input_id(form, field)}
+      {value, opts} -> {opts, input_id(form, field, value)}
+    end
+
+    opts = Keyword.put_new(opts, :for, input_id)
     content_tag(:label, opts, do: block)
   end
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1460,25 +1460,23 @@ defmodule Phoenix.HTML.Form do
   See `label/2`.
   """
   def label(form, field, text, opts) when is_binary(text) and is_list(opts) do
-    {opts, input_id} =
-      case Keyword.pop(opts, :value) do
-        {nil, opts} -> {opts, input_id(form, field)}
-        {value, opts} -> {opts, input_id(form, field, value)}
-      end
-
-    opts = Keyword.put_new(opts, :for, input_id)
+    opts = label_options(form, field, opts)
     content_tag(:label, text, opts)
   end
 
   def label(form, field, opts, do: block) do
+    opts = label_options(form, field, opts)
+    content_tag(:label, opts, do: block)
+  end
+
+  defp label_options(form, field, opts) do
     {opts, input_id} =
       case Keyword.pop(opts, :value) do
         {nil, opts} -> {opts, input_id(form, field)}
         {value, opts} -> {opts, input_id(form, field, value)}
       end
 
-    opts = Keyword.put_new(opts, :for, input_id)
-    content_tag(:label, opts, do: block)
+    Keyword.put_new(opts, :for, input_id)
   end
 
   # Normalize field name to string version

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1460,20 +1460,22 @@ defmodule Phoenix.HTML.Form do
   See `label/2`.
   """
   def label(form, field, text, opts) when is_binary(text) and is_list(opts) do
-    {opts, input_id} = case Keyword.pop(opts, :value) do
-      {nil, opts} -> {opts, input_id(form, field)}
-      {value, opts} -> {opts, input_id(form, field, value)}
-    end
+    {opts, input_id} =
+      case Keyword.pop(opts, :value) do
+        {nil, opts} -> {opts, input_id(form, field)}
+        {value, opts} -> {opts, input_id(form, field, value)}
+      end
 
     opts = Keyword.put_new(opts, :for, input_id)
     content_tag(:label, text, opts)
   end
 
   def label(form, field, opts, do: block) do
-    {opts, input_id} = case Keyword.pop(opts, :value) do
-      {nil, opts} -> {opts, input_id(form, field)}
-      {value, opts} -> {opts, input_id(form, field, value)}
-    end
+    {opts, input_id} =
+      case Keyword.pop(opts, :value) do
+        {nil, opts} -> {opts, input_id(form, field)}
+        {value, opts} -> {opts, input_id(form, field, value)}
+      end
 
     opts = Keyword.put_new(opts, :for, input_id)
     content_tag(:label, opts, do: block)

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -1174,8 +1174,7 @@ defmodule Phoenix.HTML.FormTest do
   end
 
   test "label/4 with for_value option" do
-    assert safe_form(&label(&1, :key, value: "1")) ==
-            ~s(<label for="search_key_1">Key</label>)
+    assert safe_form(&label(&1, :key, value: "1")) == ~s(<label for="search_key_1">Key</label>)
   end
 
   test "label/3 with a block" do

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -1173,6 +1173,11 @@ defmodule Phoenix.HTML.FormTest do
              ~s(<label class="test-label" for="search_key">Hello</label>)
   end
 
+  test "label/4 with for_value option" do
+    assert safe_form(&label(&1, :key, value: "1")) ==
+            ~s(<label for="search_key_1">Key</label>)
+  end
+
   test "label/3 with a block" do
     assert safe_form(&label(&1, :key, do: "Hello")) == ~s(<label for="search_key">Hello</label>)
   end


### PR DESCRIPTION
This will allow labels to be used with dynamically created radiobuttons and checkboxes to have the correct prefix.

For example this will now be allowed:

```elixir
radio_button :user, :level, :gold
label :user, :level, value: :gold
```

which will produce:

```html
<input id="user_level_gold" name="user[level]" type="radio" value="gold">
<label for="user_level_gold"></label>
```

It'll be an improvement over the current way where you'd either have to build the `for` attribute yourself.

Could be a followup on #195