### PR TITLE
Fix inconsistencies with time input.

### DIFF
--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -27,6 +27,7 @@ defmodule Phoenix.HTML.FormTest do
     Plug.Test.conn(:get, "/foo", %{
       "search" => %{
         "key" => "value",
+        "time" => ~T[01:02:03.004005],
         "alt_key" => nil,
         "datetime" => %{
           "year" => "2020",
@@ -455,6 +456,17 @@ defmodule Phoenix.HTML.FormTest do
   test "time_input/3 with form" do
     assert safe_form(&time_input(&1, :key)) ==
              ~s(<input id="search_key" name="search[key]" type="time" value="value">)
+
+    assert safe_form(&time_input(&1, :time)) ==
+             ~s(<input id="search_time" name="search[time]" type="time" value="01:02">)
+
+    if Version.match?(System.version(), ">= 1.6.0") do
+      assert safe_form(&time_input(&1, :time, precision: :second)) ==
+               ~s(<input id="search_time" name="search[time]" type="time" value="01:02:03">)
+
+      assert safe_form(&time_input(&1, :time, precision: :millisecond)) ==
+               ~s(<input id="search_time" name="search[time]" type="time" value="01:02:03.004">)
+    end
 
     assert safe_form(&time_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
              ~s(<input id="key" name="search[key][]" type="time" value="foo">)

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -56,7 +56,7 @@ defmodule Phoenix.HTML.TagTest do
              "<p class=\"dark\"><Hello></p>"
 
     content =
-      content_tag(:form, action: "/users", data: [remote: true]) do
+      content_tag :form, action: "/users", data: [remote: true] do
         tag(:input, name: "user[name]")
       end
 
@@ -130,7 +130,7 @@ defmodule Phoenix.HTML.TagTest do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(
-             form_tag("/") do
+             form_tag "/" do
                "<>"
              end
            ) ==
@@ -139,7 +139,7 @@ defmodule Phoenix.HTML.TagTest do
                ~s(<input name="_utf8" type="hidden" value="✓">) <> ~s(&lt;&gt;) <> ~s(</form>)
 
     assert safe_to_string(
-             form_tag("/", method: :get) do
+             form_tag "/", method: :get do
                "<>"
              end
            ) ==


### PR DESCRIPTION
- Allow truncation precision to be configured.
- Get value from input_value to perform truncation in case value was not
specified in opts. <- This fixes the inconsistencies with the input value.
- Run `mix format` (Elixir 1.6.3)
