### PR TITLE
Replace hash symbol with destination address in link helper

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -24,7 +24,7 @@ defmodule Phoenix.HTML.Link do
 
       # If you supply a method other than `:get`:
       link("delete", to: "/everything", method: :delete)
-      #=> <a href="#" data-csrf="csrf_token" data-method="delete" data-to="/everything">delete</a>
+      #=> <a href="/everything" data-csrf="csrf_token" data-method="delete" data-to="/everything">delete</a>
 
       # You can use a `do ... end` block too:
       link to: "/hello" do
@@ -103,7 +103,7 @@ defmodule Phoenix.HTML.Link do
     else
       {csrf_data, opts} = csrf_data(to, opts)
       opts = Keyword.put_new(opts, :rel, "nofollow")
-      content_tag(:a, text, [href: "#", data: [method: method, to: to] ++ csrf_data] ++ opts)
+      content_tag(:a, text, [href: to, data: [method: method, to: to] ++ csrf_data] ++ opts)
     end
   end
 

--- a/test/phoenix_html/csrf_test.exs
+++ b/test/phoenix_html/csrf_test.exs
@@ -7,12 +7,12 @@ defmodule Phoenix.HTML.CSRFTest do
 
   test "link with post using a custom csrf token" do
     assert safe_to_string(link("hello", to: "/world", method: :post)) =~
-             ~r(<a data-csrf="[^"]+" data-method="post" data-to="/world" href="#" rel="nofollow">hello</a>)
+             ~r(<a data-csrf="[^"]+" data-method="post" data-to="/world" href="/world" rel="nofollow">hello</a>)
   end
 
   test "link with put/delete using a custom csrf token" do
     assert safe_to_string(link("hello", to: "/world", method: :put)) =~
-             ~r(<a data-csrf="[^"]+" data-method="put" data-to="/world" href="#" rel="nofollow">hello</a>)
+             ~r(<a data-csrf="[^"]+" data-method="put" data-to="/world" href="/world" rel="nofollow">hello</a>)
   end
 
   test "button with post using a custom csrf token" do

--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -8,19 +8,19 @@ defmodule Phoenix.HTML.LinkTest do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(link("hello", to: "/world", method: :post)) ==
-             ~s[<a data-csrf="#{csrf_token}" data-method="post" data-to="/world" href="#" rel="nofollow">hello</a>]
+             ~s[<a data-csrf="#{csrf_token}" data-method="post" data-to="/world" href="/world" rel="nofollow">hello</a>]
   end
 
   test "link with put/delete" do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(link("hello", to: "/world", method: :put)) ==
-             ~s[<a data-csrf="#{csrf_token}" data-method="put" data-to="/world" href="#" rel="nofollow">hello</a>]
+             ~s[<a data-csrf="#{csrf_token}" data-method="put" data-to="/world" href="/world" rel="nofollow">hello</a>]
   end
 
   test "link with put/delete without csrf_token" do
     assert safe_to_string(link("hello", to: "/world", method: :put, csrf_token: false)) ==
-             ~s[<a data-method="put" data-to="/world" href="#" rel="nofollow">hello</a>]
+             ~s[<a data-method="put" data-to="/world" href="/world" rel="nofollow">hello</a>]
   end
 
   test "link with :do contents" do


### PR DESCRIPTION
Changes for issuee #207 

Before the change every href attribute got set to `#` in the link helper if the method option isn't `:get`. This PR changes the current behaviour to set the href attribute to the destination address. That shouldn't have any side effects because both link to the current page.