### PR TITLE
fix datetime_select documentation

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1193,8 +1193,8 @@ defmodule Phoenix.HTML.Form do
             {gettext("December"), "12"},
           ])
 
-      datetime_select(form, field, opts)
-    end
+        datetime_select(form, field, opts)
+      end
 
   ## Options
 


### PR DESCRIPTION
Trailing `end` is not formatted correctly

![image](https://user-images.githubusercontent.com/12120657/40042314-321b2836-5821-11e8-8f9b-7c11bc3204b2.png)
