### PR TITLE
Configurable and extendable data-confirm behaviour

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -42,21 +42,20 @@ defmodule Phoenix.HTML.Link do
 
   All other options are forwarded to the underlying `<a>` tag.
 
-  ## Data attributes
+  ## JavaScript dependency
 
-  Data attributes are added as a keyword list passed to the
-  `data` key. The following data attributes are supported:
+  In order to support links where `:method` is not `:get` or use the above
+  data attributes, `Phoenix.HTML` relies on JavaScript. You can load
+  `priv/static/phoenix_html.js` into your build tool.
+
+  ### Data attributes
+
+  Data attributes are added as a keyword list passed to the `data` key.
+  The following data attributes are supported:
 
     * `data-confirm` - shows a confirmation prompt before
       generating and submitting the form when `:method`
       is not `:get`.
-
-  ## JavaScript dependency
-
-  In order to support links where `:method` is not `:get`
-  or use the above data attributes, `Phoenix.HTML` relies
-  on JavaScript. You can load `priv/static/phoenix_html.js`
-  into your build tool.
 
   ### Overriding the default confirm behaviour
 

--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -58,6 +58,51 @@ defmodule Phoenix.HTML.Link do
   on JavaScript. You can load `priv/static/phoenix_html.js`
   into your build tool.
 
+  ### Overriding the default confirm behaviour
+
+  `phoenix_html.js` does trigger a custom event `phoenix.link.click` on the 
+  clicked DOM element when a click happened. This allows you to intercept the
+  event on it's way bubbling up to `window` and do your own custom logic to 
+  enhance or replace how the `data-confirm` attribute is handled.
+
+  You could for example replace the browsers `confirm()` behavior with a 
+  custom javascript implementation:
+
+  ```javascript
+  // listen on document.body, so it's executed before the default of 
+  // phoenix_html, which is listening on the window object
+  document.body.addEventListener('phoenix.link.click', function (e) {
+    // Prevent default implementation
+    e.stopPropagation();
+    
+    // Introduce alternative implementation
+    var message = e.target.getAttribute("data-confirm");
+    if(!message){ return true; }
+    vex.dialog.confirm({
+      message: message,
+      callback: function (value) {
+        if (value == false) { e.preventDefault(); } 
+      }
+    })
+  }, false);
+  ```
+
+  Or you could attach your own custom behavior.
+
+  ```javascript
+  window.addEventListener('phoenix.link.click', function (e) {
+    // Introduce custom behaviour
+    var message = e.target.getAttribute("data-prompt");
+    var answer = e.target.getAttribute("data-prompt-answer");
+    if(message && answer && (answer != window.prompt(message))) {
+      e.preventDefault();
+    }
+  }, false);
+  ```
+
+  The latter could also be bound to any `click` event, but this way you can be 
+  sure your custom code is only executed when the code of `phoenix_html.js` is run.
+
   ## CSRF Protection
 
   By default, CSRF tokens are generated through `Plug.CSRFProtection`.

--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -43,25 +43,15 @@
     form.submit();
   }
 
-  function canceledConfirm(element) {
-    var phoenixLinkEvent = new PolyfillEvent('phoenix.confirm.click', {
-      "bubbles": true, "cancelable": true
-    });
-    return !link.dispatchEvent(phoenixLinkEvent);
-  }
-
-  window.addEventListener('phoenix.confirm.click', function (e) {
-    var message = e.target.getAttribute("data-confirm");
-    if(message && !window.confirm(message)) {
-      e.preventDefault();
-    }
-  }, false);
-
   window.addEventListener("click", function(e) {
     var element = e.target;
 
     while (element && element.getAttribute) {
-      if (element.getAttribute("data-confirm") && canceledConfirm(element)) {
+      var phoenixLinkEvent = new PolyfillEvent('phoenix.link.click', {
+        "bubbles": true, "cancelable": true
+      });
+
+      if (!link.dispatchEvent(phoenixLinkEvent)) {
         e.preventDefault();
         return false;
       }
@@ -73,6 +63,13 @@
       } else {
         element = element.parentNode;
       }
+    }
+  }, false);
+
+  window.addEventListener('phoenix.link.click', function (e) {
+    var message = e.target.getAttribute("data-confirm");
+    if(message && !window.confirm(message)) {
+      e.preventDefault();
     }
   }, false);
 })();


### PR DESCRIPTION
This change does allow for two things 

* People can customize the data-confirm behaviour:
```javascript
// document.body, so it's executed before the default of phoenix_html
document.body.addEventListener('phoenix.link', function (e) {
  // Prevent default behaviour
  e.stopPropagation();
  
  // Introduce alternative behaviour
  var message = e.target.getAttribute("data-confirm");
  if(!message){ return true; }
  vex.dialog.confirm({
    message: message,
    callback: function (value) {
      if (value == false) { e.preventDefault(); } 
    }
  })
}, false);
```

* Or add their own logic besides the phoenix data-confirm default behaviour (https://github.com/phoenixframework/phoenix_html/issues/206):

```javascript
window.addEventListener('phoenix.link', function (e) {
  // Introduce custom behaviour
  var message = e.target.getAttribute("data-prompt");
  var answer = e.target.getAttribute("data-prompt-answer");
  if(message && answer && (answer != window.prompt(message))) {
    e.preventDefault();
  }
}, false);
```

I've not looked extensively into cross browser support for it by now, but wanted to propose the idea first. There might be some work needed on that front.

[Demo](https://jsfiddle.net/lostkobrakai/54t1a1po/2/)