### PR TITLE
Support ISO 8601 formatted strings for date values.

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1350,6 +1350,13 @@ defmodule Phoenix.HTML.Form do
   defp time_value({hour, min, sec}), do: %{hour: hour, minute: min, second: sec}
 
   defp time_value(nil), do: %{hour: nil, minute: nil, second: nil}
+
+  defp time_value(string) when is_binary(string) do
+    string
+    |> Time.from_iso8601!()
+    |> time_value
+  end
+
   defp time_value(other), do: raise(ArgumentError, "unrecognized time #{inspect(other)}")
 
   @months [

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1249,6 +1249,7 @@ defmodule Phoenix.HTML.Form do
 
     * a map containing the `year`, `month` and `day` keys (either as strings or atoms)
     * a tuple with three elements: `{year, month, day}`
+    * a string in ISO 8601 format
     * `nil`
 
   ## Supported time values
@@ -1282,7 +1283,7 @@ defmodule Phoenix.HTML.Form do
   """
   def date_select(form, field, opts \\ []) do
     value = Keyword.get(opts, :value, input_value(form, field) || Keyword.get(opts, :default))
-    builder = Keyword.get(opts, :builder) || (&date_builder(&1, opts))
+    builder = Keyword.get(opts, :builder) || &date_builder(&1, opts)
     builder.(datetime_builder(form, field, date_value(value), nil, opts))
   end
 
@@ -1300,6 +1301,13 @@ defmodule Phoenix.HTML.Form do
   defp date_value({year, month, day}), do: %{year: year, month: month, day: day}
 
   defp date_value(nil), do: %{year: nil, month: nil, day: nil}
+
+  defp date_value("" <> string) do
+    string
+    |> Date.from_iso8601!()
+    |> date_value
+  end
+
   defp date_value(other), do: raise(ArgumentError, "unrecognized date #{inspect(other)}")
 
   @doc """
@@ -1309,7 +1317,7 @@ defmodule Phoenix.HTML.Form do
   """
   def time_select(form, field, opts \\ []) do
     value = Keyword.get(opts, :value, input_value(form, field) || Keyword.get(opts, :default))
-    builder = Keyword.get(opts, :builder) || (&time_builder(&1, opts))
+    builder = Keyword.get(opts, :builder) || &time_builder(&1, opts)
     builder.(datetime_builder(form, field, nil, time_value(value), opts))
   end
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1302,7 +1302,7 @@ defmodule Phoenix.HTML.Form do
 
   defp date_value(nil), do: %{year: nil, month: nil, day: nil}
 
-  defp date_value("" <> string) do
+  defp date_value(string) when is_binary(string) do
     string
     |> Date.from_iso8601!()
     |> date_value

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -938,6 +938,11 @@ defmodule Phoenix.HTML.FormTest do
     assert content =~ ~s(<option value="9" selected>09</option>)
     assert content =~ ~s(<option value="9" selected>09</option>)
 
+    content = safe_to_string(time_select(:search, :datetime, value: "02:11:13.123Z", second: []))
+    assert content =~ ~s(<option value="2" selected>02</option>)
+    assert content =~ ~s(<option value="11" selected>11</option>)
+    assert content =~ ~s(<option value="13" selected>13</option>)
+
     content = safe_to_string(time_select(:search, :datetime, value: {2, 11, 13}, second: []))
     assert content =~ ~s(<option value="2" selected>02</option>)
     assert content =~ ~s(<option value="11" selected>11</option>)

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -851,6 +851,11 @@ defmodule Phoenix.HTML.FormTest do
     assert content =~ ~s(<option value="4" selected>April</option>)
     assert content =~ ~s(<option value="17" selected>17</option>)
 
+    content = safe_to_string(date_select(:search, :datetime, value: "2020-04-17"))
+    assert content =~ ~s(<option value="2020" selected>2020</option>)
+    assert content =~ ~s(<option value="4" selected>April</option>)
+    assert content =~ ~s(<option value="17" selected>17</option>)
+
     content =
       safe_to_string(date_select(:search, :datetime, value: %{year: 2020, month: 04, day: 07}))
 


### PR DESCRIPTION
This change allows ISO 8601 formatted strings to be passed as the value for date inputs.

Specifically, we're have an issue where we're passing an ISO 8601 string to a `date_select`.