### PR TITLE
Allow data-confirm with submit buttons

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -137,6 +137,14 @@ defmodule Phoenix.HTML.Link do
     * `:method` - the method to use with the button. Defaults to :post.
 
   All other options are forwarded to the underlying button input.
+
+  ## Data attributes
+
+  Data attributes are added as a keyword list passed to the
+  `data` key. The following data attributes are supported:
+
+    * `data-confirm` - shows a confirmation prompt before generating and
+      submitting the form.
   """
   def button(opts, do: contents) do
     button(contents, opts)

--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -10,11 +10,6 @@
   }
 
   function handleClick(element) {
-    var message = element.getAttribute("data-confirm");
-    if(message && !window.confirm(message)) {
-        return;
-    }
-
     var to = element.getAttribute("data-to"),
         method = buildHiddenInput("_method", element.getAttribute("data-method")),
         csrf = buildHiddenInput("_csrf_token", element.getAttribute("data-csrf")),
@@ -33,11 +28,21 @@
     form.submit();
   }
 
+  function canceledConfirm(element) {
+    var message = element.getAttribute("data-confirm");
+    return message && !window.confirm(message);
+  }
+
   window.addEventListener("click", function(e) {
     var element = e.target;
 
     while (element && element.getAttribute) {
-      if(element.getAttribute("data-method")) {
+      if (element.getAttribute("data-confirm") && canceledConfirm(element)) {
+        e.preventDefault();
+        return false;
+      }
+
+      if (element.getAttribute("data-method")) {
         handleClick(element);
         e.preventDefault();
         return false;

--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -9,19 +9,19 @@
     return input;
   }
 
-  function handleLinkClick(link) {
-    var message = link.getAttribute("data-confirm");
+  function handleClick(element) {
+    var message = element.getAttribute("data-confirm");
     if(message && !window.confirm(message)) {
         return;
     }
 
-    var to = link.getAttribute("data-to"),
-        method = buildHiddenInput("_method", link.getAttribute("data-method")),
-        csrf = buildHiddenInput("_csrf_token", link.getAttribute("data-csrf")),
+    var to = element.getAttribute("data-to"),
+        method = buildHiddenInput("_method", element.getAttribute("data-method")),
+        csrf = buildHiddenInput("_csrf_token", element.getAttribute("data-csrf")),
         form = document.createElement("form"),
-        target = link.getAttribute("target");
+        target = element.getAttribute("target");
 
-    form.method = (link.getAttribute("data-method") === "get") ? "get" : "post";
+    form.method = (element.getAttribute("data-method") === "get") ? "get" : "post";
     form.action = to;
     form.style.display = "hidden";
 
@@ -38,7 +38,7 @@
 
     while (element && element.getAttribute) {
       if(element.getAttribute("data-method")) {
-        handleLinkClick(element);
+        handleClick(element);
         e.preventDefault();
         return false;
       } else {


### PR DESCRIPTION
Coming from Rails, and seeing that Phoenix has support for confirming actions with the `data-confirm` attribute, I naturally assumed that this would work with buttons as well. Turns out it does indeed work with buttons, but maybe that's just an undocumented accident. It works because the JS does not check the element type, it is only looking for the `data-method` attribute. 

Unfortunately, that also means that it will _not_ work with standard form submit buttons, because these lack the aforementioned `data-method` attribute. I find it very useful to have this option in full fledged forms though. I often find myself using a button first to sketch out a feature, then I find out later that we need to send additional data via form, so the button gets replaced with a form. Although the `data-confirm` attribute stays, it will no longer have an effect and thus might lead to a regression. Apparently, [others](https://elixirforum.com/t/data-confirm-and-data-disable-in-forms/1633) have also been stumbling across this before me.

For now, the only possible workaround is to add separate code to handle `data-confirm` attributes for all elements which do _not_ have a `data-method` attribute. In fact that is what I am doing now:

```js
"use strict";

(function() {
  window.addEventListener("click", function(e) {
    var element = e.target;

    while (element && element.getAttribute) {
      if (!element.getAttribute("data-method") && element.getAttribute("data-confirm")) {
        var message = element.getAttribute("data-confirm");
        if (message && !window.confirm(message)) {
          e.preventDefault();
          return false;
        }
      } else {
        element = element.parentNode;
      }
    }
  }, false);
})();
```

I think most people will agree that this doesn't feel quite right for two reasons:

1. coupling between seemingly unrelated data attributes/features
2. duplication of the confirmation dialog handling code (even if it's just two lines, the same code is already in `phoenix_html` and might change in the future).

From my point of view the `data-method` and `data-confirm` mechanisms should really be two separate features, and I think it will be very handy to make `data-confirm` usable with submit buttons.

That's why I made this PR and landed here, so please let me know what you think :wink: