### PR TITLE
Fix typo 'link' instead of 'element' on click handler

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -51,7 +51,7 @@
         "bubbles": true, "cancelable": true
       });
 
-      if (!link.dispatchEvent(phoenixLinkEvent)) {
+      if (!element.dispatchEvent(phoenixLinkEvent)) {
         e.preventDefault();
         return false;
       }


### PR DESCRIPTION
`link` is not defined. The `dispatchEvent` should be called on the event target.

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent