### PR TITLE
add errors in the conn to the form

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -93,6 +93,24 @@ defmodule Phoenix.HTML.Form do
   request parameters. In this case, the input's value would be set
   to `@conn.params["search"]["for"]`.
 
+  #### A note on `:errors`
+
+  When you feed `form_for/4` with `:errors` as an option you will be able to use
+  your favorite `error_tag`-helper like:
+
+    def error_tag(form, field) do
+      if error = form.errors[field] do
+        content_tag :span, translate_error(error), class: "help-block"
+      end
+    end
+
+  For example, put the errors in the conn.assigns and create your form like this:
+
+    <%= form_for @conn, '/', [errors: @conn.assigns[:errors]], fn f -> %>
+      <%= text_input f, :field %>
+      <%= error_tag f, :field %>
+    <% end %>
+
   ## Without form data
 
   Sometimes we may want to generate a `text_input/3` or any other
@@ -274,6 +292,11 @@ defmodule Phoenix.HTML.Form do
       to "UTF-8" and a hidden input named `_utf8` containing a unicode
       character to force the browser to use UTF-8 as the charset. When set to
       false, this is disabled.
+
+    * `:errors` - use this to manually pass errors to the form (for example
+      from `conn.assigns[:errors]`). These are made available on the form struct
+      that is passed to the function as the argument f. This makes it easy to
+      access it as `f.errors`.
 
     * Other options will be passed as html attributes.
       ie, `class: "foo", id: "bar"`

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -98,18 +98,18 @@ defmodule Phoenix.HTML.Form do
   When you feed `form_for/4` with `:errors` as an option you will be able to use
   your favorite `error_tag`-helper like:
 
-    def error_tag(form, field) do
-      if error = form.errors[field] do
-        content_tag :span, translate_error(error), class: "help-block"
+      def error_tag(form, field) do
+        if error = form.errors[field] do
+          content_tag :span, translate_error(error), class: "help-block"
+        end
       end
-    end
 
   For example, put the errors in the conn.assigns and create your form like this:
 
-    <%= form_for @conn, '/', [errors: @conn.assigns[:errors]], fn f -> %>
-      <%= text_input f, :field %>
-      <%= error_tag f, :field %>
-    <% end %>
+      <%= form_for @conn, '/', [errors: @conn.assigns[:errors]], fn f -> %>
+        <%= text_input f, :field %>
+        <%= error_tag f, :field %>
+      <% end %>
 
   ## Without form data
 
@@ -293,10 +293,10 @@ defmodule Phoenix.HTML.Form do
       character to force the browser to use UTF-8 as the charset. When set to
       false, this is disabled.
 
-    * `:errors` - use this to manually pass errors to the form (for example
-      from `conn.assigns[:errors]`). These are made available on the form struct
-      that is passed to the function as the argument f. This makes it easy to
-      access it as `f.errors`.
+    * `:errors` - use this to manually pass a keyword list of errors to the form
+      (for example from `conn.assigns[:errors]`). This option is only used when a
+      connection is used as the form source and it will make the errors available
+      under `f.errors`.
 
     * Other options will be passed as html attributes.
       ie, `class: "foo", id: "bar"`

--- a/lib/phoenix_html/form_data.ex
+++ b/lib/phoenix_html/form_data.ex
@@ -60,14 +60,17 @@ defimpl Phoenix.HTML.FormData, for: Plug.Conn do
           {name, Map.get(conn.params, name) || %{}, opts}
       end
 
+    {errors, opts} = Keyword.pop(opts, :errors, [])
+
     %Phoenix.HTML.Form{
       source: conn,
       impl: __MODULE__,
       id: name,
       name: name,
       params: params,
-      options: opts,
-      data: %{}
+      data: %{},
+      errors: errors,
+      options: opts
     }
   end
 

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -112,6 +112,21 @@ defmodule Phoenix.HTML.FormTest do
     assert form =~ ~s(<input id="key" name="key" type="text">)
   end
 
+  test "form_for/4 with errors through options" do
+    errors = [field: {"error message!", []}]
+
+    form =
+      safe_to_string(
+        form_for(conn, "/", [errors: errors], fn f ->
+          for {field, {message, _}} <- f.errors do
+            Phoenix.HTML.Tag.content_tag(:span, humanize(field) <> " " <> message, class: "errors")
+          end
+        end)
+      )
+
+    assert form =~ ~s(<span class="errors">Field error message!</span>)
+  end
+
   ## text_input/3
 
   test "text_input/3" do

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -117,7 +117,7 @@ defmodule Phoenix.HTML.FormTest do
 
     form =
       safe_to_string(
-        form_for(conn, "/", [errors: errors], fn f ->
+        form_for(conn(), "/", [errors: errors], fn f ->
           for {field, {message, _}} <- f.errors do
             Phoenix.HTML.Tag.content_tag(:span, humanize(field) <> " " <> message, class: "errors")
           end


### PR DESCRIPTION
When creating a form with the conn instead of with a changeset struct, there is no easy way of displaying error messages.

This is an attempt to make that easier by allowing `:errors` as an option to `form_for/4`.
In the controller:
```ex
def my_post_method(conn, params) do
  case do_stuff(params) do
    {:ok, object} -> render(conn, view_template)
    {:error, reason} -> render(conn, view_template, errors: reason)
  end
end
```
and in the template
```eex
<%= form_for @conn, "/do_stuff", [errors: @conn.assigns[:errors]], fn f -> do %>
  <%= text_input f, :field %>
  <%= error_tag f, :field %>
<% end %>
```
where `error_tag` is the custom function as mentioned in the [migration guides](https://gist.github.com/chrismccord/557ef22e2a03a7992624).