### PR TITLE
Add option to not send values from unchecked checkbox

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -877,6 +877,9 @@ defmodule Phoenix.HTML.Form do
     * `:checked_value` - the value to be sent when the checkbox is checked.
       Defaults to "true"
 
+    * `:hidden_input` - the value to check if a checkox will generate a hidden input or not,
+      Defaults to "true"
+
     * `:unchecked_value` - the value to be sent when the checkbox is unchecked,
       Defaults to "false"
 
@@ -890,7 +893,8 @@ defmodule Phoenix.HTML.Form do
   Because an unchecked checkbox is not sent to the server, Phoenix
   automatically generates a hidden field with the unchecked_value
   *before* the checkbox field to ensure the `unchecked_value` is sent
-  when the checkbox is not marked.
+  when the checkbox is not marked. Set `hidden_input` to false If you
+  don't want to send values from unchecked checkbox to the server.
   """
   def checkbox(form, field, opts \\ []) do
     opts =
@@ -902,6 +906,7 @@ defmodule Phoenix.HTML.Form do
     {value, opts} = Keyword.pop(opts, :value, input_value(form, field))
     {checked_value, opts} = Keyword.pop(opts, :checked_value, true)
     {unchecked_value, opts} = Keyword.pop(opts, :unchecked_value, false)
+    {hidden_input, opts} = Keyword.pop(opts, :hidden_input, true)
 
     # We html escape all values to be sure we are comparing
     # apples to apples. After all we may have true in the data
@@ -917,10 +922,16 @@ defmodule Phoenix.HTML.Form do
         opts
       end
 
-    html_escape([
-      tag(:input, name: Keyword.get(opts, :name), type: "hidden", value: unchecked_value),
-      tag(:input, [value: checked_value] ++ opts)
-    ])
+    if hidden_input do
+      html_escape([
+        tag(:input, name: Keyword.get(opts, :name), type: "hidden", value: unchecked_value),
+        tag(:input, [value: checked_value] ++ opts)
+      ])
+    else
+      html_escape([
+        tag(:input, [value: checked_value] ++ opts)
+      ])
+    end
   end
 
   @doc """

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -877,8 +877,8 @@ defmodule Phoenix.HTML.Form do
     * `:checked_value` - the value to be sent when the checkbox is checked.
       Defaults to "true"
 
-    * `:hidden_input` - the value to check if a checkox will generate a hidden input or not,
-      Defaults to "true"
+    * `:hidden_input` - the value to check if a checkbox will generate a hidden input
+      for the unchecked value or not. Defaults to "true"
 
     * `:unchecked_value` - the value to be sent when the checkbox is unchecked,
       Defaults to "false"

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -877,8 +877,8 @@ defmodule Phoenix.HTML.Form do
     * `:checked_value` - the value to be sent when the checkbox is checked.
       Defaults to "true"
 
-    * `:hidden_input` - the value to check if a checkbox will generate a hidden input
-      for the unchecked value or not. Defaults to "true"
+    * `:hidden_input` - controls if this function will generate a hidden input
+      to submit the unchecked value or not. Defaults to "true"
 
     * `:unchecked_value` - the value to be sent when the checkbox is unchecked,
       Defaults to "false"

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -578,6 +578,9 @@ defmodule Phoenix.HTML.FormTest do
     assert safe_to_string(checkbox(:search, :key, value: 1, checked_value: 1, unchecked_value: 0)) ==
              ~s(<input name="search[key]" type="hidden" value="0">) <>
                ~s(<input id="search_key" name="search[key]" type="checkbox" value="1" checked>)
+
+    assert safe_to_string(checkbox(:search, :key, value: 1, hidden_input: false)) ==
+               ~s(<input id="search_key" name="search[key]" type="checkbox" value="true">)
   end
 
   test "checkbox/3 with form" do


### PR DESCRIPTION
fixes https://github.com/phoenixframework/phoenix_html/issues/232

Sometimes we don't want to send values from unchecked checkboxes to the server (e.g. when using a filter form and GET requests).

This PR allows developers to set the option `hidden_input: false` to not generate the hidden input. This way, the value will not be sent to the server if the checkbox is unchecked.