### PR TITLE
Optimize documentation for `Form.HTML.input_name/2`

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -414,10 +414,17 @@ defmodule Phoenix.HTML.Form do
   @doc """
   Returns a name of a corresponding form field.
 
-  The form should either be a `Phoenix.HTML.Form` emitted
+  The first param should either be a `Phoenix.HTML.Form` emitted
   by `form_for` or an atom.
+
+  ## Examples
+
+      iex> Phoenix.HTML.Form.input_name(:user, :first_name)
+      "user[first_name]"
   """
   @spec input_name(t | atom, field) :: String.t()
+  def input_name(form_or_name, field)
+
   def input_name(%{name: nil}, field), do: to_string(field)
 
   def input_name(%{name: name}, field) when is_atom(field) or is_binary(field),

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -414,7 +414,7 @@ defmodule Phoenix.HTML.Form do
   @doc """
   Returns a name of a corresponding form field.
 
-  The first param should either be a `Phoenix.HTML.Form` emitted
+  The first argument should either be a `Phoenix.HTML.Form` emitted
   by `form_for` or an atom.
 
   ## Examples


### PR DESCRIPTION
Super small change but I tripped over the documentation a few times since the first param is parsed and displayed as `name` although it can be `form` or `name`. The documentation says as much but then again, who reads documentations right? 😅 