### PR TITLE
fix dialyzer complaining about nil action in to_form

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -262,7 +262,7 @@ defmodule Phoenix.HTML.Form do
           impl: module,
           id: String.t(),
           index: nil | non_neg_integer,
-          action: String.t
+          action: nil | String.t
         }
 
   @type field :: atom | String.t()


### PR DESCRIPTION
Fixes dialyzer warning
```
The inferred return type of to_form/2 (#{'__struct__':='Elixir.Phoenix.HTML.Form', 'action':='nil', 'data':=#{}, 'errors':=_, 'hidden':=[], 'id':=_, 'impl':='Elixir.Phoenix.HTML.FormData.Plug.Conn', 'index':='nil', 'name':=_, 'options':=[{atom(),_}], 'params':=_, 'source':=atom() | #{'params':=_, _=>_}}) has nothing in common with #{'__struct__':='Elixir.Phoenix.HTML.Form', 'action':=binary(), 'data':=#{atom() | binary()=>_}, 'errors':=[{atom(),_}], 'hidden':=[{atom(),_}], 'id':=binary(), 'impl':=atom(), 'index':='nil' | non_neg_integer(), 'name':=binary(), 'options':=[{atom(),_}], 'params':=#{binary()=>_}, 'source':=_}, which is the expected return type for the callback of the 'Elixir.Phoenix.HTML.FormData' behaviour
```
see https://github.com/phoenixframework/phoenix_html/issues/239