### PR TITLE
Implement ability to pass in HTML safe strings to label/4

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1615,10 +1615,6 @@ defmodule Phoenix.HTML.Form do
   """
   def label(form, field, text_or_do_block_or_attributes)
 
-  def label(form, field, text) when is_binary(text) do
-    label(form, field, text, [])
-  end
-
   def label(form, field, do: block) do
     label(form, field, [], do: block)
   end
@@ -1627,19 +1623,23 @@ defmodule Phoenix.HTML.Form do
     label(form, field, humanize(field), opts)
   end
 
+  def label(form, field, text) do
+    label(form, field, text, [])
+  end
+
   @doc """
   See `label/2`.
   """
   def label(form, field, text, do_block_or_attributes)
 
-  def label(form, field, text, opts) when is_binary(text) and is_list(opts) do
-    opts = Keyword.put_new(opts, :for, input_id(form, field))
-    content_tag(:label, text, opts)
-  end
-
   def label(form, field, opts, do: block) when is_list(opts) do
     opts = Keyword.put_new(opts, :for, input_id(form, field))
     content_tag(:label, block, opts)
+  end
+
+  def label(form, field, text, opts) when is_list(opts) do
+    opts = Keyword.put_new(opts, :for, input_id(form, field))
+    content_tag(:label, text, opts)
   end
 
   # Normalize field name to string version

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -1241,6 +1241,11 @@ defmodule Phoenix.HTML.FormTest do
                ~s(<label class="foo" for="test_key">Search</label>)
     end
 
+    test "with field and inline safe content" do
+      assert safe_to_string(label(:search, :key, {:safe, "<em>Search</em>"})) ==
+               ~s(<label for="search_key"><em>Search</em></label>)
+    end
+
     test "with field and block content" do
       assert safe_form(&label(&1, :key, do: "Hello")) == ~s(<label for="search_key">Hello</label>)
 


### PR DESCRIPTION
A couple of the other HTML functions allow passing in HTML safe tuples directly, in lieu of text. This PR adds the same functionality for the `label/4` function.

With this, you can do something like:

```elixir
<%= label @applicant_form, :additional_info, {:safe, "Additional <span>Information</span>"} %>
```

On the intent itself - I can agree that passing in HTML as a `:safe` tuple directly is not good idea. As mentioned, I've often overloaded the `text` arg in `link(text, opts)` to allow HTML (not realizing that the `link/2` function allows `do` blocks as well.

The only good reason for merging this is in because we usually passthrough the `text` argument eventually to `html_escape`, which is responsible for making this value usable. It seems arbitrary and inconsistent for some APIs to passthrough without prejudice (such as the `link/2` tag), and for other APIs to have the `when is_binary(text)` guard clause.

