### PR TITLE
escape backticks in javascript_escape/1

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -193,7 +193,7 @@ defmodule Phoenix.HTML do
   defp javascript_escape(<<"\r\n", t::binary>>, acc),
     do: javascript_escape(t, <<acc::binary, ?\\, ?n>>)
 
-  defp javascript_escape(<<h, t::binary>>, acc) when h in [?", ?', ?\\],
+  defp javascript_escape(<<h, t::binary>>, acc) when h in [?", ?', ?\\, ?`],
     do: javascript_escape(t, <<acc::binary, ?\\, h>>)
 
   defp javascript_escape(<<h, t::binary>>, acc) when h in [?\r, ?\n],

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -15,6 +15,7 @@ defmodule Phoenix.HTMLTest do
     assert javascript_escape("\\Double backslash") == "\\\\Double backslash"
     assert javascript_escape("\"Double quote\"") == "\\\"Double quote\\\""
     assert javascript_escape("'Single quote'") == "\\'Single quote\\'"
+    assert javascript_escape("`Backtick`") == "\\`Backtick\\`"
     assert javascript_escape("New line\r") == "New line\\n"
     assert javascript_escape("New line\n") == "New line\\n"
     assert javascript_escape("New line\r\n") == "New line\\n"


### PR DESCRIPTION
At the time of the implementation of the javascript_escape function backticks weren't an issue as the string interpolation syntax was not broadly supported in javascript. This is now widely used and thus will introduce a vulnerability of XSS attacks.