### PR TITLE
Stop event propagation when cancel is clicked

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -53,6 +53,7 @@
 
       if (!element.dispatchEvent(phoenixLinkEvent)) {
         e.preventDefault();
+        e.stopImmediatePropagation();
         return false;
       }
 


### PR DESCRIPTION
prevents downstream listeners from receiving the canceled click