### PR TITLE
Fix typespec for form_for/2-3

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -378,8 +378,6 @@ defmodule Phoenix.HTML.Form do
   See `Phoenix.HTML.Tag.form_tag/2` for more information on the
   options above.
   """
-  @spec form_for(Phoenix.HTML.FormData.t(), String.t(), (t -> Phoenix.HTML.unsafe())) ::
-          Phoenix.HTML.safe()
   @spec form_for(Phoenix.HTML.FormData.t(), String.t(), Keyword.t(), (t -> Phoenix.HTML.unsafe())) ::
           Phoenix.HTML.safe()
   def form_for(form_data, action, options \\ [], fun) when is_function(fun, 1) do

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -378,6 +378,8 @@ defmodule Phoenix.HTML.Form do
   See `Phoenix.HTML.Tag.form_tag/2` for more information on the
   options above.
   """
+  @spec form_for(Phoenix.HTML.FormData.t(), String.t(), (t -> Phoenix.HTML.unsafe())) ::
+          Phoenix.HTML.safe()
   @spec form_for(Phoenix.HTML.FormData.t(), String.t(), Keyword.t(), (t -> Phoenix.HTML.unsafe())) ::
           Phoenix.HTML.safe()
   def form_for(form_data, action, options \\ [], fun) when is_function(fun, 1) do

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -308,7 +308,7 @@ defmodule Phoenix.HTML.Form do
 
   A shortcut for `form_for(changeset, url, [])`.
   """
-  @spec form_for(Phoenix.HTML.FormData.t(), String.t()) :: Phoenix.HTML.safe()
+  @spec form_for(Phoenix.HTML.FormData.t(), String.t()) :: Phoenix.HTML.Form.t()
   def form_for(form_data, action) do
     form_for(form_data, action, [])
   end
@@ -330,7 +330,7 @@ defmodule Phoenix.HTML.Form do
   See `form_for/4` for the available options.
   """
   @spec form_for(Phoenix.HTML.FormData.t(), String.t(), Keyword.t()) ::
-          Phoenix.HTML.safe()
+          Phoenix.HTML.Form.t()
   def form_for(form_data, action, options) when is_list(options) do
     %{Phoenix.HTML.FormData.to_form(form_data, options) | action: action}
   end


### PR DESCRIPTION
Closes #239

One small problem with current approach was that docs showed both spec clauses in docs for form_for/3 which was supposed to be only about the variant without anonymous function. See https://github.com/phoenixframework/phoenix_html/commit/cae0f75e51fe53de8edb783173790f235cb74604 for more details. When I removed the clause, however, dialyzer complains again, so it needs to be there.