### PR TITLE
Allow `inputs_for` to skip hidden fields for more control over the final markup

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -412,7 +412,7 @@ defmodule Phoenix.HTML.Form do
 
     * `:skip_hidden` - skip the automatic rendering of hidden
       fields to allow for more tight control over the generated
-      markup. You can use `hidden_fields_of_form(form)` to 
+      markup. You can use `hidden_form_inputs(form)` to
       generate them manually within the supplied callback.
 
   """
@@ -420,7 +420,7 @@ defmodule Phoenix.HTML.Form do
   def inputs_for(%{impl: impl} = form, field, options \\ [], fun)
       when is_atom(field) or is_binary(field) do
     {skip, options} = Keyword.pop(options, :skip_hidden, false)
-    
+
     options =
       form.options
       |> Keyword.take([:multipart])
@@ -433,16 +433,16 @@ defmodule Phoenix.HTML.Form do
         if skip do
           fun.(form)
         else
-          [hidden_fields_of_form(form), fun.(form)]
+          [hidden_form_inputs(form), fun.(form)]
         end
       end)
     )
   end
-  
+
   @doc false
-  @spec hidden_fields_of_form(t) :: [Phoenix.HTML.safe()]
-  def hidden_fields_of_form(%{hidden: hidden}) do
-    Enum.map(hidden, fn {k, v} -> hidden_input(form, k, value: v) end)
+  @spec hidden_form_inputs(t) :: [Phoenix.HTML.safe()]
+  def hidden_form_inputs(form) do
+    Enum.map(form.hidden, fn {k, v} -> hidden_input(form, k, value: v) end)
   end
 
   @doc """
@@ -1416,7 +1416,7 @@ defmodule Phoenix.HTML.Form do
   """
   def date_select(form, field, opts \\ []) do
     value = Keyword.get(opts, :value, input_value(form, field) || Keyword.get(opts, :default))
-    builder = Keyword.get(opts, :builder) || &date_builder(&1, opts)
+    builder = Keyword.get(opts, :builder) || (&date_builder(&1, opts))
     builder.(datetime_builder(form, field, date_value(value), nil, opts))
   end
 
@@ -1450,7 +1450,7 @@ defmodule Phoenix.HTML.Form do
   """
   def time_select(form, field, opts \\ []) do
     value = Keyword.get(opts, :value, input_value(form, field) || Keyword.get(opts, :default))
-    builder = Keyword.get(opts, :builder) || &time_builder(&1, opts)
+    builder = Keyword.get(opts, :builder) || (&time_builder(&1, opts))
     builder.(datetime_builder(form, field, nil, time_value(value), opts))
   end
 


### PR DESCRIPTION

For #258