### PR TITLE
updated datetime_local_input to format default form value if if no value is explicitly set

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -698,14 +698,8 @@ defmodule Phoenix.HTML.Form do
   See `text_input/3` for example and docs.
   """
   def datetime_local_input(form, field, opts \\ []) do
-    opts =
-      case Keyword.fetch(opts, :value) do
-        {:ok, value} ->
-          Keyword.put(opts, :value, datetime_local_input_value(value))
-
-        :error ->
-          opts
-      end
+    value = Keyword.get(opts, :value, input_value(form, field))
+    opts = Keyword.put(opts, :value, datetime_local_input_value(value))
 
     generic_input(:"datetime-local", form, field, opts)
   end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -39,7 +39,8 @@ defmodule Phoenix.HTML.FormTest do
         "hour" => "2",
         "minute" => "11",
         "second" => "13"
-      }
+      },
+      "naive_datetime" => ~N[2000-01-01 10:00:42]
     }
   end
 
@@ -549,6 +550,9 @@ defmodule Phoenix.HTML.FormTest do
     assert safe_to_string(datetime_local_input(:search, :key)) ==
              ~s(<input id="search_key" name="search[key]" type="datetime-local">)
 
+    assert safe_form(&datetime_local_input(&1, :naive_datetime)) ==
+             ~s(<input id="search_naive_datetime" name="search[naive_datetime]" type="datetime-local" value="2000-01-01T10:00">)
+              
     assert safe_to_string(
              datetime_local_input(:search, :key, value: "foo", id: "key", name: "search[key][]")
            ) == ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)


### PR DESCRIPTION
Fix an issue with datetime_local_input, the date_time does not get formatted if the value is not explicitly set.