### PR TITLE
Allow `inputs_for` to skip hidden fields for more control over the final markup

### DIFF
--- a/lib/phoenix_html/form_data.ex
+++ b/lib/phoenix_html/form_data.ex
@@ -91,6 +91,7 @@ defimpl Phoenix.HTML.FormData, for: [Plug.Conn, Atom] do
     {append, opts} = Keyword.pop(opts, :append, [])
     {name, opts} = Keyword.pop(opts, :as)
     {id, opts} = Keyword.pop(opts, :id)
+    {hidden, opts} = Keyword.pop(opts, :hidden, [])
 
     id = to_string(id || form.id <> "_#{field}")
     name = to_string(name || form.name <> "[#{field}]")
@@ -107,6 +108,7 @@ defimpl Phoenix.HTML.FormData, for: [Plug.Conn, Atom] do
             name: name,
             data: default,
             params: params || %{},
+            hidden: hidden,
             options: opts
           }
         ]
@@ -133,6 +135,7 @@ defimpl Phoenix.HTML.FormData, for: [Plug.Conn, Atom] do
             name: name <> "[" <> index_string <> "]",
             data: data,
             params: params,
+            hidden: hidden,
             options: opts
           }
         end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -260,6 +260,53 @@ defmodule Phoenix.HTML.FormTest do
     end
   end
 
+  describe "inputs_for/4" do
+    test "generate a new form builder for the given parameter" do
+      conn = conn()
+
+      form =
+          form_for(conn, "/", [as: :user], fn form ->
+            inputs_for(form, :company, fn company_form ->
+              text_input company_form, :name
+            end)
+          end)
+          |> safe_to_string()
+
+      assert form =~ ~s(<input name="_utf8" type="hidden" value="✓">)
+      assert form =~ ~s(<input id="user_company_name" name="user[company][name]" type="text">)
+    end
+
+    test "generate a new form builder with hidden inputs when they are present" do
+      conn = conn()
+
+      form =
+          form_for(conn, "/", [as: :user], fn form ->
+            inputs_for(form, :company, [hidden: [id: 1]],fn company_form ->
+              text_input company_form, :name
+            end)
+          end)
+          |> safe_to_string()
+
+      assert form =~ ~s(input id="user_company_id" name="user[company][id]" type="hidden" value="1">)
+      assert form =~ ~s(<input id="user_company_name" name="user[company][name]" type="text">)
+    end
+
+    test "skip hidden inputs" do
+      conn = conn()
+
+      form =
+          form_for(conn, "/", [as: :user], fn form ->
+            inputs_for(form, :company, [skip_hidden: true, hidden: [id: 1]],fn company_form ->
+              text_input company_form, :name
+            end)
+          end)
+          |> safe_to_string()
+
+      refute form =~ ~s(input id="user_company_id" name="user[company][id]" type="hidden" value="1">)
+      assert form =~ ~s(<input id="user_company_name" name="user[company][name]" type="text">)
+    end
+  end
+
   ## text_input/3
 
   test "text_input/3" do


### PR DESCRIPTION
Fixes #258

Continue the @LostKobrakai work https://github.com/phoenixframework/phoenix_html/pull/259