### PR TITLE
Add :srcset option to img_tag helper

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -311,8 +311,32 @@ defmodule Phoenix.HTML.Tag do
       img_tag(Routes.static_path(@conn, "/logo.png"))
       <img src="/logo-123456.png?vsn=d">
 
+  For responsive images, pass a map, list or string through `:srcset`.
+
+      img_tag("/logo.png", srcset: %{"/logo.png" => "1x", "/logo-2x.png" => "2x"})
+      <img src="/logo.png" srcset="/logo.png 1x, /logo-2x.png 2x">
+
+      img_tag("/logo.png", srcset: ["/logo.png", {"/logo-2x.png", "2x"}])
+      <img src="/logo.png" srcset="/logo.png, /logo-2x.png 2x">
+
   """
   def img_tag(src, opts \\ []) do
+    opts =
+      case Keyword.pop(opts, :srcset) do
+        {nil, opts} -> opts
+        {srcset, opts} -> [srcset: stringify_srcset(srcset)] ++ opts
+      end
+
     tag(:img, Keyword.put_new(opts, :src, src))
   end
+
+  defp stringify_srcset(srcset) when is_map(srcset) or is_list(srcset) do
+    Enum.map_join(srcset, ", ", fn
+      {src, descriptor} -> "#{src} #{descriptor}"
+      default -> default
+    end)
+  end
+
+  defp stringify_srcset(srcset) when is_binary(srcset),
+    do: srcset
 end

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -92,6 +92,16 @@ defmodule Phoenix.HTML.TagTest do
 
     assert img_tag("user.png", class: "big") |> safe_to_string() ==
              ~s(<img class="big" src="user.png">)
+
+    assert img_tag("user.png", srcset: %{"big.png" => "2x", "small.png" => "1x"})
+           |> safe_to_string() ==
+             ~s(<img src="user.png" srcset="big.png 2x, small.png 1x">)
+
+    assert img_tag("user.png", srcset: [{"big.png", "2x"}, "small.png"]) |> safe_to_string() ==
+             ~s(<img src="user.png" srcset="big.png 2x, small.png">)
+
+    assert img_tag("user.png", srcset: "big.png 2x, small.png") |> safe_to_string() ==
+             ~s[<img src="user.png" srcset="big.png 2x, small.png">]
   end
 
   test "form_tag for get" do


### PR DESCRIPTION
For responsive `<img>`s, alternate files can be supplied by the `srcset` attribute.

```html
<img src="/logo.png" srcset="/logo.png 1x, /logo-2x.png 2x">
```

This pull request supports stringifying `srcset` values from a map or list.

```elixir
img_tag("/logo.png", srcset: %{"/logo.png" => "1x", "/logo-2x.png" => "2x"})
img_tag("/logo.png", srcset: [{"/logo.png", "1x"}, {"/logo-2x.png", "2x"}])
```

Support for stringifying `sizes` was considered because the algorithm is identical, but `sizes` is likely hard-coded whereas `srcset` is generated from multiple `Routes.static_path`s.

```html
<img src="/logo.png"
  srcset="/logo-100.png 100w, /logo-200.png 200w"
   sizes="(min-width: 100px) 50vw, 100vw">
```

So simply passing `sizes: "(min-width: 100px) 50vw, 100vw"` here would work.