### PR TITLE
Remove :enforce_utf8 option

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -352,11 +352,6 @@ defmodule Phoenix.HTML.Form do
       include an input tag with name `_csrf_token`. When set to false, this
       is disabled
 
-    * `:enforce_utf8` - the form will have an `accept-charset` attribute set
-      to "UTF-8" and a hidden input named `_utf8` containing a unicode
-      character to force the browser to use UTF-8 as the charset. When set to
-      false, this is disabled.
-
     * `:errors` - use this to manually pass a keyword list of errors to the form
       (for example from `conn.assigns[:errors]`). This option is only used when a
       connection is used as the form source and it will make the errors available

--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -173,23 +173,7 @@ defmodule Phoenix.HTML.Tag do
       include an input tag with name `_csrf_token`. When set to false, this
       is disabled
 
-    * `:enforce_utf8` - when false, does not enforce utf8. Read below
-      for more information
-
   All other options are passed to the underlying HTML tag.
-
-  ## Enforce UTF-8
-
-  Although forms provide the `accept-charset` attribute, which we set
-  to UTF-8, Internet Explorer 5 up to 8 may ignore the value of this
-  attribute if the user chooses their browser to do so. This ends up
-  triggering the browser to send data in a format that is not
-  understandable by the server.
-
-  For this reason, Phoenix automatically includes a "_utf8=✓" parameter
-  in your forms, to force those browsers to send the data in the proper
-  encoding. This technique has been seen in the Rails web framework and
-  reproduced here.
 
   ## CSRF Protection
 
@@ -222,16 +206,6 @@ defmodule Phoenix.HTML.Tag do
             Keyword.put(opts, :method, "post"),
             ~s'<input name="#{@method_param}" type="hidden" value="#{method}">'
           )
-      end
-
-    {opts, extra} =
-      case Keyword.pop(opts, :enforce_utf8, true) do
-        {false, opts} ->
-          {opts, extra}
-
-        {true, opts} ->
-          {Keyword.put_new(opts, :accept_charset, "UTF-8"),
-           extra <> ~s'<input name="_utf8" type="hidden" value="✓">'}
       end
 
     opts =

--- a/test/phoenix_html/csrf_test.exs
+++ b/test/phoenix_html/csrf_test.exs
@@ -22,18 +22,16 @@ defmodule Phoenix.HTML.CSRFTest do
 
   test "form_tag for post using a custom csrf token" do
     assert safe_to_string(form_tag("/")) =~ ~r(
-                <form\ accept-charset="UTF-8"\ action="/"\ method="post">
+                <form\ action="/"\ method="post">
                 <input\ name="_csrf_token"\ type="hidden"\ value="[^"]+">
-                <input\ name="_utf8"\ type="hidden"\ value="✓">
               )mx
   end
 
   test "form_tag for other method using a custom csrf token" do
     assert safe_to_string(form_tag("/", method: :put)) =~ ~r(
-                <form\ accept-charset="UTF-8"\ action="/"\ method="post">
+                <form\ action="/"\ method="post">
                 <input\ name="_method"\ type="hidden"\ value="put">
                 <input\ name="_csrf_token"\ type="hidden"\ value="[^"]+">
-                <input\ name="_utf8"\ type="hidden"\ value="✓">
               )mx
   end
 

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -52,8 +52,7 @@ defmodule Phoenix.HTML.FormTest do
       assert %Phoenix.HTML.Form{} = form
 
       contents = form |>  html_escape() |> safe_to_string()
-      assert contents =~ ~s(<form accept-charset="UTF-8" action="/" method="post">)
-      assert contents =~ ~s(<input name="_utf8" type="hidden" value="✓">)
+      assert contents =~ ~s(<form action="/" method="post">)
     end
 
     test "with custom options" do
@@ -61,7 +60,7 @@ defmodule Phoenix.HTML.FormTest do
       assert %Phoenix.HTML.Form{} = form
 
       contents = form |>  html_escape() |> safe_to_string()
-      assert contents =~ ~s(<form accept-charset="UTF-8" action="/" enctype="multipart/form-data" method="post">)
+      assert contents =~ ~s(<form action="/" enctype="multipart/form-data" method="post">)
       assert contents =~ ~s(method="post")
       assert contents =~ ~s(<input name="_method" type="hidden" value="put">)
       refute contents =~ ~s(</form>)
@@ -74,16 +73,18 @@ defmodule Phoenix.HTML.FormTest do
       assert %Phoenix.HTML.Form{} = form
 
       contents = form |> html_escape() |> safe_to_string()
-      assert contents =~ ~s(<form accept-charset="UTF-8" action="/" method="post">)
-      assert contents =~ ~s(<input name="_utf8" type="hidden" value="✓">)
+      assert contents =~ ~s(<form action="/" method="post">)
     end
 
     test "with custom options" do
       form = form_for(:search, "/", [method: :put, multipart: true])
       assert %Phoenix.HTML.Form{} = form
 
-      contents = form |>  html_escape() |> safe_to_string()
-      assert contents =~ ~s(<form accept-charset="UTF-8" action="/" enctype="multipart/form-data" method="post">)
+      contents = form |> html_escape() |> safe_to_string()
+
+      assert contents =~
+               ~s(<form action="/" enctype="multipart/form-data" method="post">)
+
       assert contents =~ ~s(method="post")
       assert contents =~ ~s(<input name="_method" type="hidden" value="put">)
       refute contents =~ ~s(</form>)
@@ -105,8 +106,7 @@ defmodule Phoenix.HTML.FormTest do
           end)
         )
 
-      assert form =~ ~s(<form accept-charset="UTF-8" action="/" method="post">)
-      assert form =~ ~s(<input name="_utf8" type="hidden" value="✓">)
+      assert form =~ ~s(<form action="/" method="post">)
     end
 
     test "without :as" do
@@ -132,7 +132,7 @@ defmodule Phoenix.HTML.FormTest do
         )
 
       assert form =~
-               ~s(<form accept-charset="UTF-8" action="/" enctype="multipart/form-data" method="post">)
+               ~s(<form action="/" enctype="multipart/form-data" method="post">)
 
       assert form =~ ~s(<input name="_method" type="hidden" value="put">)
     end
@@ -189,8 +189,7 @@ defmodule Phoenix.HTML.FormTest do
           end)
         )
 
-      assert form =~ ~s(<form accept-charset="UTF-8" action="/" method="post">)
-      assert form =~ ~s(<input name="_utf8" type="hidden" value="✓">)
+      assert form =~ ~s(<form action="/" method="post">)
     end
 
     test "with params" do
@@ -216,7 +215,7 @@ defmodule Phoenix.HTML.FormTest do
         )
 
       assert form =~
-               ~s(<form accept-charset="UTF-8" action="/" enctype="multipart/form-data" method="post">)
+               ~s(<form action="/" enctype="multipart/form-data" method="post">)
 
       assert form =~ ~s(<input name="_method" type="hidden" value="put">)
     end
@@ -272,7 +271,6 @@ defmodule Phoenix.HTML.FormTest do
           end)
           |> safe_to_string()
 
-      assert form =~ ~s(<input name="_utf8" type="hidden" value="✓">)
       assert form =~ ~s(<input id="user_company_name" name="user[company][name]" type="text">)
     end
 
@@ -599,7 +597,7 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_form(&datetime_local_input(&1, :naive_datetime)) ==
              ~s(<input id="search_naive_datetime" name="search[naive_datetime]" type="datetime-local" value="2000-01-01T10:00">)
-              
+
     assert safe_to_string(
              datetime_local_input(:search, :key, value: "foo", id: "key", name: "search[key][]")
            ) == ~s(<input id="key" name="search[key][]" type="datetime-local" value="foo">)

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -106,10 +106,9 @@ defmodule Phoenix.HTML.TagTest do
 
   test "form_tag for get" do
     assert safe_to_string(form_tag("/", method: :get)) ==
-             ~s(<form accept-charset="UTF-8" action="/" method="get">) <>
-               ~s(<input name="_utf8" type="hidden" value="✓">)
+             ~s(<form action="/" method="get">)
 
-    assert safe_to_string(form_tag("/", method: :get, enforce_utf8: false)) ==
+    assert safe_to_string(form_tag("/", method: :get)) ==
              ~s(<form action="/" method="get">)
   end
 
@@ -117,23 +116,20 @@ defmodule Phoenix.HTML.TagTest do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(form_tag("/")) ==
-             ~s(<form accept-charset="UTF-8" action="/" method="post">) <>
-               ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">) <>
-               ~s(<input name="_utf8" type="hidden" value="✓">)
+             ~s(<form action="/" method="post">) <>
+               ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">)
 
     assert safe_to_string(form_tag("/", method: :post, csrf_token: false, multipart: true)) ==
-             ~s(<form accept-charset="UTF-8" action="/" enctype="multipart/form-data" method="post">) <>
-               ~s(<input name="_utf8" type="hidden" value="✓">)
+             ~s(<form action="/" enctype="multipart/form-data" method="post">)
   end
 
   test "form_tag for other method" do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
 
     assert safe_to_string(form_tag("/", method: :put)) ==
-             ~s(<form accept-charset="UTF-8" action="/" method="post">) <>
+             ~s(<form action="/" method="post">) <>
                ~s(<input name="_method" type="hidden" value="put">) <>
-               ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">) <>
-               ~s(<input name="_utf8" type="hidden" value="✓">)
+               ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">)
   end
 
   test "form_tag with do block" do
@@ -144,17 +140,17 @@ defmodule Phoenix.HTML.TagTest do
                "<>"
              end
            ) ==
-             ~s(<form accept-charset="UTF-8" action="/" method="post">) <>
+             ~s(<form action="/" method="post">) <>
                ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">) <>
-               ~s(<input name="_utf8" type="hidden" value="✓">) <> ~s(&lt;&gt;) <> ~s(</form>)
+               ~s(&lt;&gt;) <> ~s(</form>)
 
     assert safe_to_string(
              form_tag "/", method: :get do
                "<>"
              end
            ) ==
-             ~s(<form accept-charset="UTF-8" action="/" method="get">) <>
-               ~s(<input name="_utf8" type="hidden" value="✓">) <> ~s(&lt;&gt;) <> ~s(</form>)
+             ~s(<form action="/" method="get">) <>
+               ~s(&lt;&gt;) <> ~s(</form>)
   end
 
   test "csrf_meta_tag" do


### PR DESCRIPTION
The hidden `_utf8=✓` form field hasn't been needed since IE 8, and given that browser is now three years in the grave, it might be time to remove this.

Rails, where this concept came from, disabled this last year: https://github.com/rails/rails/pull/32125

This MR does not remove `accept-charset="UTF-8"`. That might also be superfluous, but I haven't researched how well browsers handle that.