### PR TITLE
Disable testing on OTP 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: elixir
 matrix:
   include:
     - elixir: 1.5
-      otp_release: 18.3
-    - elixir: 1.5
       otp_release: 19.3
     - elixir: 1.5
       otp_release: 20.3


### PR DESCRIPTION
As also noted [over here](https://github.com/phoenixframework/phoenix_html/pull/268#issuecomment-522332831), installing OTP 18.3 on Travis no longer works due to the release no longer being available at the URL Travis tries to download it from.

Given how relatively ancient OTP 18 is, I guess it might make sense to simply stop supporting it.