### PR TITLE
`class_list` attributes for HTML tags

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -131,8 +131,8 @@ defmodule Phoenix.HTML.Tag do
   end
 
   defp build_attrs(tag, [{k, v} | t], acc) when k in @list_attrs and is_list(v) do
-    {k_actual, interleave_char} = Map.fetch!(@list_attrs_map, k)
-    build_attrs(tag, t, [{dasherize(k_actual), interleave(v, interleave_char)} | acc])
+    {k_actual, interleave_str} = Map.fetch!(@list_attrs_map, k)
+    build_attrs(tag, t, [{dasherize(k_actual), interleave(v, interleave_str)} | acc])
   end
 
   defp build_attrs(tag, [{k, true} | t], acc) do
@@ -154,10 +154,10 @@ defmodule Phoenix.HTML.Tag do
   defp dasherize(value) when is_atom(value), do: dasherize(Atom.to_string(value))
   defp dasherize(value) when is_binary(value), do: String.replace(value, "_", "-")
 
-  def interleave(list, char) do
+  def interleave(list, str) do
     List.foldr(list, [], fn
       item, [] -> [item]
-      item, acc -> [item, char] ++ acc
+      item, acc -> [item, str] ++ acc
     end)
   end
 

--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -9,6 +9,10 @@ defmodule Phoenix.HTML.Tag do
   import Phoenix.HTML
 
   @tag_prefixes [:aria, :data]
+  @list_attrs_map %{
+    class_list: :class
+  }
+  @list_attrs Map.keys(@list_attrs_map)
   @csrf_param "_csrf_token"
   @method_param "_method"
 
@@ -126,6 +130,10 @@ defmodule Phoenix.HTML.Tag do
     build_attrs(tag, t, nested_attrs(dasherize(k), v, acc))
   end
 
+  defp build_attrs(tag, [{k, v} | t], acc) when k in @list_attrs and is_list(v) do
+    build_attrs(tag, t, [{dasherize(Map.fetch!(@list_attrs_map, k)), interleave(v, " ")} | acc])
+  end
+
   defp build_attrs(tag, [{k, true} | t], acc) do
     build_attrs(tag, t, [dasherize(k) | acc])
   end
@@ -144,6 +152,13 @@ defmodule Phoenix.HTML.Tag do
 
   defp dasherize(value) when is_atom(value), do: dasherize(Atom.to_string(value))
   defp dasherize(value) when is_binary(value), do: String.replace(value, "_", "-")
+
+  def interleave(list, char) do
+    List.foldr(list, [], fn
+      item, [] -> [item]
+      item, acc -> [item, char] ++ acc
+    end)
+  end
 
   @doc ~S"""
   Generates a form tag.

--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -10,7 +10,7 @@ defmodule Phoenix.HTML.Tag do
 
   @tag_prefixes [:aria, :data]
   @list_attrs_map %{
-    class_list: :class
+    class_list: {:class, " "}
   }
   @list_attrs Map.keys(@list_attrs_map)
   @csrf_param "_csrf_token"
@@ -131,7 +131,8 @@ defmodule Phoenix.HTML.Tag do
   end
 
   defp build_attrs(tag, [{k, v} | t], acc) when k in @list_attrs and is_list(v) do
-    build_attrs(tag, t, [{dasherize(Map.fetch!(@list_attrs_map, k)), interleave(v, " ")} | acc])
+    {k_actual, interleave_char} = Map.fetch!(@list_attrs_map, k)
+    build_attrs(tag, t, [{dasherize(k_actual), interleave(v, interleave_char)} | acc])
   end
 
   defp build_attrs(tag, [{k, true} | t], acc) do

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -55,6 +55,9 @@ defmodule Phoenix.HTML.TagTest do
     assert content_tag(:p, [class: "dark"], do: raw("<Hello>")) |> safe_to_string() ==
              "<p class=\"dark\"><Hello></p>"
 
+   assert content_tag(:p, "Hello", class_list: ["dark", "light"]) |> safe_to_string() ==
+            "<p class=\"dark light\">Hello</p>"
+
     content =
       content_tag :form, action: "/users", data: [remote: true] do
         tag(:input, name: "user[name]")


### PR DESCRIPTION
**Before**

```eex
<%= input @form, @field, class: Enum.join(" ", ["form-control"] ++ bootstrap_error_classes(@form, @field)) %>
```

**After**

```eex
<%= input @form, @field, class_list: ["form-control"] ++ bootstrap_error_classes(@form, @field) %>
```

This PR tries to make this pattern less verbose, and probably more efficient as well. Most people won't know that `Enum.join` isn't always the best idea for performance - passing in `IOData` is better.

The implementation is flexible enough that we could allow other HTML attributes to be set this way, and the string to interleave between members can be changed per attribute. In the case of `class_list`, that string is `" "`. For `style_list`, for example, it could be `"; "`