### PR TITLE
remove Enum.sort in build_attrs/3

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -120,7 +120,7 @@ defmodule Phoenix.HTML.Tag do
   defp build_attrs(_tag, []), do: []
   defp build_attrs(tag, attrs), do: build_attrs(tag, attrs, [])
 
-  defp build_attrs(_tag, [], acc), do: acc |> Enum.sort() |> tag_attrs
+  defp build_attrs(_tag, [], acc), do: acc |> tag_attrs
 
   defp build_attrs(tag, [{k, v} | t], acc) when k in @tag_prefixes and is_list(v) do
     build_attrs(tag, t, nested_attrs(dasherize(k), v, acc))


### PR DESCRIPTION
Hi.
When you want to make \<meta property="og:title" content="variable"\>,
you write  <%= content_tag(:meta, nil, [property: "og:title", content: variable]) %>.
( variable = "variable" )

But, <%= content_tag(:meta, nil, [property: "og:title", content: variable]) %> will be <meta  content="variable" property="og:title">, and it doesn't work well.