### PR TITLE
Allow strings in content_tag

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -72,19 +72,19 @@ defmodule Phoenix.HTML.Tag do
       "<option data-foo=\"bar\" value=\"value\">Display Value</option>"
 
   """
-  def content_tag(name, do: block) when is_atom(name) do
+  def content_tag(name, do: block) do
     content_tag(name, block, [])
   end
 
-  def content_tag(name, content) when is_atom(name) do
+  def content_tag(name, content) do
     content_tag(name, content, [])
   end
 
-  def content_tag(name, attrs, do: block) when is_atom(name) and is_list(attrs) do
+  def content_tag(name, attrs, do: block) when is_list(attrs) do
     content_tag(name, block, attrs)
   end
 
-  def content_tag(name, content, attrs) when is_atom(name) and is_list(attrs) do
+  def content_tag(name, content, attrs) when is_list(attrs) do
     name = to_string(name)
     {:safe, escaped} = html_escape(content)
     {:safe, [?<, name, build_attrs(name, attrs), ?>, escaped, ?<, ?/, name, ?>]}

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -85,6 +85,8 @@ defmodule Phoenix.HTML.TagTest do
     assert content_tag(:div, [autoplay: false], do: "") |> safe_to_string() == ~s(<div></div>)
 
     assert content_tag(:div, [autoplay: nil], do: "") |> safe_to_string() == ~s(<div></div>)
+
+    assert content_tag("custom-tag", "Hi") |> safe_to_string() == ~s(<custom-tag>Hi</custom-tag>)
   end
 
   test "img_tag" do


### PR DESCRIPTION
Closes #281 

This removes the `is_atom` guard clauses on the `content_tag` functions allowing strings to be passed.

    content_tag("custom-component", "Hello")