### PR TITLE
bugfix(phoenix_html.js): Make IIFE idempotent by injecting a global _…

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -1,6 +1,8 @@
 "use strict";
 
-(function() {
+(function(loaded) {
+  if (loaded) { return }
+
   var PolyfillEvent = eventConstructor();
 
   function eventConstructor() {
@@ -73,4 +75,6 @@
       e.preventDefault();
     }
   }, false);
-})();
+
+  window._phx_loaded = true;
+})(window._phx_loaded);


### PR DESCRIPTION
…phx_loaded boolean flag that is set after setup. Prevents event handlers from being set multiple times in case of libraries like turbolinks which would run this code several times.

@josevalim @chrismccord fixes #284.

After taking some time to think about the problem, I took a different approach than what I outlined in the previous discussion. I think this is a simpler and more robust solution to the problem since there is not much javascript actually being executed. Let me know what you think.