### PR TITLE
Improve docs for Phoenix.HTML.Form submit/2 

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -850,17 +850,34 @@ defmodule Phoenix.HTML.Form do
   @doc """
   Generates a submit button to send the form.
 
+  ## Examples
+
+      submit do: "Submit"
+      #=> <button type="submit">Submit</button>
+
+  """
+  def submit([do: _] = block_option), do: submit([], block_option)
+
+  @doc """
+  Generates a submit button to send the form.
+
   All options are forwarded to the underlying button tag.
+  When called with a `do:` block, the button tag options
+  come first.
 
   ## Examples
 
       submit "Submit"
       #=> <button type="submit">Submit</button>
 
-  """
-  def submit([do: _] = block_option), do: submit([], block_option)
+      submit "Submit", class: "btn"
+      #=> <button class="btn" type="submit">Submit</button>
 
-  def submit(_, opts \\ [])
+      submit [class: "btn"], do: "Submit"
+      #=> <button class="btn" type="submit">Submit</button>
+
+  """
+  def submit(value, opts \\ [])
 
   def submit(opts, [do: _] = block_option) do
     opts = Keyword.put_new(opts, :type, "submit")


### PR DESCRIPTION
It listed opts twice like so `submit(opts, opts \ [])`, which was confusing at least to me.

**Screenshot of new version:**
![newversion](https://user-images.githubusercontent.com/28652/74107038-0a4f3f80-4b64-11ea-8f22-b908d6774c73.jpg)



**Screenshot of old version:**
![oldversion](https://user-images.githubusercontent.com/28652/74107041-10452080-4b64-11ea-8d05-9c6c2a154b70.jpg)
