### PR TITLE
Disable hidden input for disabled checkboxes

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1014,7 +1014,12 @@ defmodule Phoenix.HTML.Form do
 
     if hidden_input do
       html_escape([
-        tag(:input, name: Keyword.get(opts, :name), type: "hidden", value: unchecked_value),
+        tag(:input,
+          name: Keyword.get(opts, :name),
+          type: "hidden",
+          value: unchecked_value,
+          disabled: Keyword.get(opts, :disabled, false)
+        ),
         tag(:input, [value: checked_value] ++ opts)
       ])
     else

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -748,6 +748,10 @@ defmodule Phoenix.HTML.FormTest do
              ~s(<input name="search[key]" type="hidden" value="false">) <>
                ~s(<input id="search_key" name="search[key]" type="checkbox" value="true" checked>)
 
+    assert safe_to_string(checkbox(:search, :key, checked: true, disabled: true)) ==
+             ~s(<input name="search[key]" type="hidden" value="false" disabled>) <>
+               ~s(<input id="search_key" name="search[key]" type="checkbox" value="true" checked disabled>)
+
     assert safe_to_string(checkbox(:search, :key, value: "true", checked: false)) ==
              ~s(<input name="search[key]" type="hidden" value="false">) <>
                ~s(<input id="search_key" name="search[key]" type="checkbox" value="true">)


### PR DESCRIPTION
When a checkbox is disabled, it doesn't send its value when the form is submitted - but the still-active hidden input DOES. The result is that a disabled checkbox will always submit as its unchecked value (`"false"` by default).

See also https://github.com/rails/rails/issues/1953 where a similar helper function had the same bug with the same fix.

Not 100% certain about the formatting on the change in `form.ex`; that's what running `mix format` gave me but there's a bunch of other files that that wants to change as well...