### PR TITLE
Fix inputs_form spec

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -441,6 +441,7 @@ defmodule Phoenix.HTML.Form do
       within the supplied callback.
 
   """
+  @spec inputs_for(t, field, (t -> Phoenix.HTML.unsafe())) :: Phoenix.HTML.safe()
   @spec inputs_for(t, field, Keyword.t(), (t -> Phoenix.HTML.unsafe())) :: Phoenix.HTML.safe()
   def inputs_for(%{impl: impl} = form, field, options \\ [], fun)
       when is_atom(field) or is_binary(field) do


### PR DESCRIPTION
v2.14.11 introduced a regression. Now a valid code

```
<%= inputs_for f, :my_field, fn f2 -> %>
    <div class="form-group">
      <%= label f2, :name, class: "control-label" %>
      <%= text_input f2, :name, class: "form-control" %>
      <%= error_tag f2, :name %>
    </div>
<% end %>
```
fails to dialyze with
```
The function call will not succeed.

Phoenix.HTML.Form.inputs_for(_f :: any(), :my_field, (_ -> {:safe, [any(), ...]}))

breaks the contract
(t(), field(), Keyword.t()) :: [t()]

```