### PR TITLE
Document the index field in Phoenix.HTML.Form

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -212,6 +212,8 @@ defmodule Phoenix.HTML.Form do
 
     * `:id` - the id to be used when generating input fields
 
+    * `:index` - the index of the struct in the form
+
     * `:name` - the name to be used when generating input fields
 
     * `:data` - the field used to store lookup data


### PR DESCRIPTION
Follow up to the discussion between @chrismccord and @jayjun during the night on the Elixir slack, it seemed this is not meant to be hidden from user, but is not documented.

It now is.