### PR TITLE
Fix inputs_for/3 is missing is_binary(field) guard

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -378,7 +378,8 @@ defmodule Phoenix.HTML.Form do
   Same as `inputs_for(form, field, [])`.
   """
   @spec inputs_for(t, field) :: list(Phoenix.HTML.Form.t())
-  def inputs_for(form, field) when is_atom(field), do: inputs_for(form, field, [])
+  def inputs_for(form, field) when is_atom(field) or is_binary(field),
+    do: inputs_for(form, field, [])
 
   @doc """
   Generate a new form builder for the given parameter in form **without** an
@@ -405,7 +406,7 @@ defmodule Phoenix.HTML.Form do
   """
   @spec inputs_for(t, field, Keyword.t()) :: list(Phoenix.HTML.Form.t())
   def inputs_for(%{impl: impl} = form, field, options)
-      when is_atom(field) and is_list(options) do
+      when (is_atom(field) or is_binary(field)) and is_list(options) do
     options =
       form.options
       |> Keyword.take([:multipart])

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -30,7 +30,6 @@ defmodule Phoenix.HTML.FormTest do
   defp search_params do
     %{
       "key" => "value",
-      "F✓o]o%b+a'R" => "utf8_value",
       "time" => ~T[01:02:03.004005],
       "alt_key" => nil,
       "datetime" => %{
@@ -296,13 +295,13 @@ defmodule Phoenix.HTML.FormTest do
     test "support atom or binary field" do
       form = form_for(:user, "/")
 
-      [f] = inputs_for(form, :"F✓o]o%b+a'R")
-      assert f.name == "user[F✓o]o%b+a'R]"
-      assert f.id == "user_F✓o]o%b+a'R"
+      [f] = inputs_for(form, :key)
+      assert f.name == "user[key]"
+      assert f.id == "user_key"
 
-      [f] = inputs_for(form, "F✓o]o%b+a'R")
-      assert f.name == "user[F✓o]o%b+a'R]"
-      assert f.id == "user_F✓o]o%b+a'R"
+      [f] = inputs_for(form, "key")
+      assert f.name == "user[key]"
+      assert f.id == "user_key"
     end
   end
 
@@ -1501,11 +1500,11 @@ defmodule Phoenix.HTML.FormTest do
     end
 
     test "with atom or binary field" do
-      assert safe_form(&label(&1, :"F✓o]o%b+a'R", do: "Hello")) ==
-               ~s(<label for="search_F✓o]o%b+a&#39;R">Hello</label>)
+      assert safe_form(&label(&1, :key, do: "Hello")) ==
+               ~s(<label for="search_key">Hello</label>)
 
-      assert safe_form(&label(&1, "F✓o]o%b+a'R", do: "Hello")) ==
-               ~s(<label for="search_F✓o]o%b+a&#39;R">Hello</label>)
+      assert safe_form(&label(&1, "key", do: "Hello")) ==
+               ~s(<label for="search_key">Hello</label>)
     end
   end
 
@@ -1515,13 +1514,11 @@ defmodule Phoenix.HTML.FormTest do
     assert input_value(:search, :key) == nil
     assert input_value(:search, 1) == nil
     assert input_value(:search, "key") == nil
-    assert input_value(:search, "F✓o]o%b+a'R") == nil
   end
 
   test "input_value/2 with form" do
     assert safe_form(&input_value(&1, :key)) == "value"
     assert safe_form(&input_value(&1, "key")) == "value"
-    assert safe_form(&input_value(&1, "F✓o]o%b+a'R")) == "utf8_value"
   end
 
   test "input_value/2 with form and data" do
@@ -1546,12 +1543,12 @@ defmodule Phoenix.HTML.FormTest do
 
   test "input_id/2 without form" do
     assert input_id(:search, :key) == "search_key"
-    assert input_id(:search, "F✓o]o%b+a'R") == "search_F✓o]o%b+a'R"
+    assert input_id(:search, "key") == "search_key"
   end
 
   test "input_id/2 with form" do
     assert safe_form(&input_id(&1, :key)) == "search_key"
-    assert safe_form(&input_id(&1, "F✓o]o%b+a'R")) == "search_F✓o]o%b+a&#39;R"
+    assert safe_form(&input_id(&1, "key")) == "search_key"
   end
 
   test "input_id/2 with form with no name" do
@@ -1580,11 +1577,11 @@ defmodule Phoenix.HTML.FormTest do
 
   test "input_name/2 without form" do
     assert input_name(:search, :key) == "search[key]"
-    assert input_name(:search, "F✓o]o%b+a'R") == "search[F✓o]o%b+a'R]"
+    assert input_name(:search, "key") == "search[key]"
   end
 
   test "input_name/2 with form" do
     assert safe_form(&input_name(&1, :key)) == "search[key]"
-    assert safe_form(&input_name(&1, "F✓o]o%b+a'R")) == "search[F✓o]o%b+a&#39;R]"
+    assert safe_form(&input_name(&1, "key")) == "search[key]"
   end
 end


### PR DESCRIPTION
According to 
```elixir
@type field :: atom | String.t()
```
the `inputs_for/3` is missing `is_binary(field)` guard. 

This PR adds the guard so it's consistent with the rest of module's functions which typically have `is_atom(field) or is_binary(field)` guard that allow passing binary field.

