### PR TITLE
Allow extra html attributes with select option generated with prompt

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1126,12 +1126,16 @@ defmodule Phoenix.HTML.Form do
           <option value="user">User</option>
           </select>
 
+  You can also pass a prompt:
+
       select(form, :role, ["Admin": "admin", "User": "user"], prompt: "Choose your role")
       #=> <select id="user_role" name="user[role]">
           <option value="">Choose your role</option>
           <option value="admin">Admin</option>
           <option value="user">User</option>
           </select>
+
+  And customize the prompt as any other entry:
 
       select(form, :role, ["Admin": "admin", "User": "user"], prompt: [key: "Choose your role", disabled: true])
       #=> <select id="user_role" name="user[role]">
@@ -1164,8 +1168,8 @@ defmodule Phoenix.HTML.Form do
 
   ## Options
 
-    * `:prompt` - an option to include at the top of the options with
-      the given prompt text
+    * `:prompt` - an option to include at the top of the options. It may be
+      a string or a keyword list of atttributes and the `:key`
 
     * `:selected` - the default value to use when none was sent as parameter
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1133,6 +1133,13 @@ defmodule Phoenix.HTML.Form do
           <option value="user">User</option>
           </select>
 
+      select(form, :role, ["Admin": "admin", "User": "user"], prompt: [key: "Choose your role", disabled: true])
+      #=> <select id="user_role" name="user[role]">
+          <option value="" disabled="">Choose your role</option>
+          <option value="admin">Admin</option>
+          <option value="user">User</option>
+          </select>
+
   If you want to select an option that comes from the database,
   such as a manager for a given project, you may write:
 
@@ -1174,7 +1181,7 @@ defmodule Phoenix.HTML.Form do
     {options_html, opts} =
       case Keyword.pop(opts, :prompt) do
         {nil, opts} -> {options_html, opts}
-        {prompt, opts} -> {[content_tag(:option, prompt, value: "") | options_html], opts}
+        {prompt, opts} -> {[prompt_option(prompt) | options_html], opts}
       end
 
     opts =
@@ -1183,6 +1190,24 @@ defmodule Phoenix.HTML.Form do
       |> Keyword.put_new(:name, input_name(form, field))
 
     content_tag(:select, options_html, opts)
+  end
+
+  defp prompt_option(prompt) when is_list(prompt) do
+    {prompt_key, prompt_opts} = Keyword.pop(prompt, :key)
+
+    prompt_key ||
+      raise ArgumentError,
+            "expected :key key when building a prompt select option with a keyword list: #{
+              inspect(prompt)
+            }"
+
+    prompt_option(prompt_key, prompt_opts)
+  end
+
+  defp prompt_option(key) when is_binary(key), do: prompt_option(key, [])
+
+  defp prompt_option(key, opts) when is_list(opts) do
+    content_tag(:option, key, Keyword.put_new(opts, :value, ""))
   end
 
   @doc """

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1201,9 +1201,8 @@ defmodule Phoenix.HTML.Form do
 
     prompt_key ||
       raise ArgumentError,
-            "expected :key key when building a prompt select option with a keyword list: #{
+            "expected :key key when building a prompt select option with a keyword list: " <>
               inspect(prompt)
-            }"
 
     prompt_option(prompt_key, prompt_opts)
   end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -871,6 +871,20 @@ defmodule Phoenix.HTML.FormTest do
                ~s(<option value="foo">Foo</option>) <>
                ~s(<option value="bar">Bar</option>) <> ~s(</select>)
 
+    assert safe_to_string(
+             select(:search, :key, [Foo: "foo", Bar: "bar"],
+               prompt: [key: "Choose your destiny", disabled: true]
+             )
+           ) ==
+             ~s(<select id="search_key" name="search[key]">) <>
+               ~s(<option value="" disabled>Choose your destiny</option>) <>
+               ~s(<option value="foo">Foo</option>) <>
+               ~s(<option value="bar">Bar</option>) <> ~s(</select>)
+
+    assert_raise ArgumentError, fn ->
+      select(:search, :key, [Foo: "foo", Bar: "bar"], prompt: [])
+    end
+
     assert safe_to_string(select(:search, :key, ~w(foo bar), value: "foo")) =~
              ~s(<option value="foo" selected>foo</option>)
 

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -13,7 +13,7 @@ defmodule Phoenix.HTMLTest do
            <%= "foo" %>
            """ == {:safe, ["foo", "\n"]}
 
-  assert ~E"""
+    assert ~E"""
            <%= {:safe, "foo"} %>
            """ == {:safe, ["foo", "\n"]}
   end


### PR DESCRIPTION
Closes #303 

This PR allows to add extra html attributes to a select option that has been generated with the `prompt` option.

The following code
```elixir
select(:user, :role, ["Admin": "admin", "User": "user"], prompt: [key: "Choose your role", disabled: true])
```
will generate this HTML output:
```html
<select id="user_role" name="user[role]">
    <option value="" disabled>Choose your role</option>
    <option value="admin">Admin</option>
    <option value="user">User</option>
</select>
```

Feel free to ask me for modifications if you think I could better code this behaviour, as this is my first PR in the Elixir world :partying_face:

It also seems that `mix format` corrected a typo in a test file. I can do a separate PR if needed.