### PR TITLE
Ensure form still have id when present

### DIFF
--- a/lib/phoenix_html/form_data.ex
+++ b/lib/phoenix_html/form_data.ex
@@ -52,12 +52,12 @@ defimpl Phoenix.HTML.FormData, for: [Plug.Conn, Atom] do
   def to_form(conn_or_atom, opts) do
     {name, params, opts} = name_params_and_opts(conn_or_atom, opts)
     {errors, opts} = Keyword.pop(opts, :errors, [])
-    {id, opts} = Keyword.pop(opts, :id)
+    id = Keyword.get(opts, :id) || name
 
     %Phoenix.HTML.Form{
       source: conn_or_atom,
       impl: __MODULE__,
-      id: id || name,
+      id: id,
       name: name,
       params: params,
       data: %{},

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -94,25 +94,37 @@ defmodule Phoenix.HTML.FormTest do
       form = form_for(:search, "/", id: "form_id")
       assert %Phoenix.HTML.Form{} = form
 
-      contents =
+      form_content =
+        form
+        |> html_escape()
+        |> safe_to_string()
+
+      input_content =
         form
         |> text_input(:name)
         |> html_escape()
         |> safe_to_string()
 
-      assert contents =~ ~s(<input id="form_id_name" name="search[name]" type="text">)
+      assert form_content  =~ ~s(<form action="/" id="form_id" method="post">)
+      assert input_content =~ ~s(<input id="form_id_name" name="search[name]" type="text">)
     end
 
     test "without id prefix the form name in the input id" do
       form = form_for(:search, "/")
       assert %Phoenix.HTML.Form{} = form
 
+      form_content =
+        form
+        |> html_escape()
+        |> safe_to_string()
+
       contents =
         form
         |> text_input(:name)
         |> html_escape()
         |> safe_to_string()
 
+      assert form_content  =~ ~s(<form action="/" method="post">)
       assert contents =~ ~s(<input id="search_name" name="search[name]" type="text">)
     end
   end


### PR DESCRIPTION
The last commit takes the ID from the opts so the form will never render the ID anymore. This commit fix that and ensure id will be preset with tests.
