### PR TITLE
Display file on compile warning in sigil

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -75,7 +75,7 @@ defmodule Phoenix.HTML do
 
   """
   defmacro sigil_e(expr, opts) do
-    handle_sigil(expr, opts, __CALLER__.line)
+    handle_sigil(expr, opts, __CALLER__)
   end
 
   @doc """
@@ -91,13 +91,14 @@ defmodule Phoenix.HTML do
 
   """
   defmacro sigil_E(expr, opts) do
-    handle_sigil(expr, opts, __CALLER__.line)
+    handle_sigil(expr, opts, __CALLER__)
   end
 
-  defp handle_sigil({:<<>>, meta, [expr]}, [], line) do
+  defp handle_sigil({:<<>>, meta, [expr]}, [], caller) do
     options = [
       engine: Phoenix.HTML.Engine,
-      line: line + 1,
+      file: caller.file,
+      line: caller.line + 1,
       indentation: meta[:indentation] || 0
     ]
 


### PR DESCRIPTION
Include the file in compile warnings within the ~E and ~e sigils, fixing https://github.com/phoenixframework/phoenix_html/issues/311

Before:
![Screenshot from 2020-07-17 09-14-59](https://user-images.githubusercontent.com/11598866/87840012-6e76ec00-c8d8-11ea-8116-d8a27af385fb.png)

After:
![Screenshot from 2020-07-17 09-14-49](https://user-images.githubusercontent.com/11598866/87840014-70d94600-c8d8-11ea-8856-1204f2cb33af.png)