### PR TITLE
Use to_iso8601 as the standard implementation for safe dates and times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# v3 (2020-09-18)
+
+* Backwards Incompatible 
+  * By default dates and times will format to the `to_iso8601` functions provided by their implementation.
+
+ 
 ## v2.14.2 (2020-04-30)
 
 * Deprecations

--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -37,7 +37,11 @@ defimpl Phoenix.HTML.Safe, for: NaiveDateTime do
 end
 
 defimpl Phoenix.HTML.Safe, for: DateTime do
-  defdelegate to_iodata(data), to: DateTime, as: :to_iso8601
+  def to_iodata(data) do
+    # Call escape in case someone can inject reserved
+    # characters in the timezone or its abbreviation
+    Plug.HTML.html_escape_to_iodata(DateTime.to_iso8601(data))
+  end
 end
 
 defimpl Phoenix.HTML.Safe, for: List do

--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -25,23 +25,19 @@ defimpl Phoenix.HTML.Safe, for: BitString do
 end
 
 defimpl Phoenix.HTML.Safe, for: Time do
-  defdelegate to_iodata(data), to: Time, as: :to_string
+  defdelegate to_iodata(data), to: Time, as: :to_iso8601
 end
 
 defimpl Phoenix.HTML.Safe, for: Date do
-  defdelegate to_iodata(data), to: Date, as: :to_string
+  defdelegate to_iodata(data), to: Date, as: :to_iso8601
 end
 
 defimpl Phoenix.HTML.Safe, for: NaiveDateTime do
-  defdelegate to_iodata(data), to: NaiveDateTime, as: :to_string
+  defdelegate to_iodata(data), to: NaiveDateTime, as: :to_iso8601
 end
 
 defimpl Phoenix.HTML.Safe, for: DateTime do
-  def to_iodata(data) do
-    # Call escape in case someone can inject reserved
-    # characters in the timezone or its abbreviation
-    Plug.HTML.html_escape_to_iodata(DateTime.to_string(data))
-  end
+  defdelegate to_iodata(data), to: DateTime, as: :to_iso8601
 end
 
 defimpl Phoenix.HTML.Safe, for: List do

--- a/test/phoenix_html/safe_test.exs
+++ b/test/phoenix_html/safe_test.exs
@@ -41,7 +41,7 @@ defmodule Phoenix.HTML.SafeTest do
 
   test "impl for NaiveDateTime" do
     {:ok, datetime} = NaiveDateTime.new(2000, 1, 1, 12, 13, 14)
-    assert Safe.to_iodata(datetime) == "2000-01-01 12:13:14"
+    assert Safe.to_iodata(datetime) == "2000-01-01T12:13:14"
   end
 
   test "impl for DateTime" do
@@ -59,10 +59,6 @@ defmodule Phoenix.HTML.SafeTest do
       utc_offset: 3600
     }
 
-    assert Safe.to_iodata(datetime) ==
-             [
-               [[[[], "2000-01-01 12:13:14+00:30 " | "&lt;"], "H" | "&gt;"], " " | "&lt;"],
-               "Hello" | "&gt;"
-             ]
+    assert Safe.to_iodata(datetime) == "2000-01-01T12:13:14+00:30"
   end
 end


### PR DESCRIPTION
Most browsers are fine with with the non-iso-standard to_string we provide in Elixir that does not include the T but some browsers, Safari in particular, will choke and blow up. Using the ISO standard as a default and asking the user to format or choose their own representation is a more clear choice. 

This change does regress and will not use a users configured timezone abbr by default but they can simply call the function to fix that. 

(Please ignore the branch name)