### PR TITLE
Add documentation about query parameters for button/2

### DIFF
--- a/lib/phoenix_html/link.ex
+++ b/lib/phoenix_html/link.ex
@@ -188,6 +188,11 @@ defmodule Phoenix.HTML.Link do
 
   All other options are forwarded to the underlying button input.
 
+  When the `:method` is set to `:get` and the `:to` URL contains query
+  parameters the generated form element will strip the parameters in accordance
+  with the [W3C](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.3.4)
+  form specification.
+
   ## Data attributes
 
   Data attributes are added as a keyword list passed to the


### PR DESCRIPTION
According to the W3C specification the query parameters in the action
field of a form will be stripped when submitting a form with the method
get.

Closes: #317