### PR TITLE
Respect modifier key clicks for links with :method opt

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -24,7 +24,7 @@
     return input;
   }
 
-  function handleClick(element) {
+  function handleClick(element, targetModifierKey) {
     var to = element.getAttribute("data-to"),
         method = buildHiddenInput("_method", element.getAttribute("data-method")),
         csrf = buildHiddenInput("_csrf_token", element.getAttribute("data-csrf")),
@@ -36,6 +36,7 @@
     form.style.display = "hidden";
 
     if (target) form.target = target;
+    else if (targetModifierKey) form.target = "_blank";
 
     form.appendChild(csrf);
     form.appendChild(method);
@@ -58,7 +59,7 @@
       }
 
       if (element.getAttribute("data-method")) {
-        handleClick(element);
+        handleClick(element, e.metaKey || e.shiftKey);
         e.preventDefault();
         return false;
       } else {


### PR DESCRIPTION
Makes it so that the behavior of modifier key clicks (cmd/ctrl + click, shift + click) on links with a `:method` opt more closely matches that of normal links. Does so by adding `target="_blank"` to the hidden form when a modifier key is used.

Preference is given to the existing link target, if present.

## Testing

Chrome: Matches normal links exactly
Safari: cmd + click matches exactly, shift + click opens a new window (instead of adding to reading list)
Firefox: Both cmd + click and shift + click open a focused new tab

The behavior doesn't match normal links exactly, however it tends not to be far off. Whereas before, the link would always result in navigation in the current browser tab.

Closes #319 