### PR TITLE
Add Tag.attributes_escape/1

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -96,6 +96,9 @@ defmodule Phoenix.HTML.Tag do
   @doc """
   Escapes a list of attributes, returning iodata.
 
+  Pay attention that, unlike `Phoenix.HTML.Tag.tag/2` and `Phoenix.HTML.Tag.content_tag/2`, this
+  function does not sort the attributes.
+
       iex> attributes_escape(title: "the title", id: "the id", selected: true)
       {:safe,
        [

--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -96,7 +96,7 @@ defmodule Phoenix.HTML.Tag do
   @doc """
   Escapes a list of attributes, returning iodata.
 
-  Pay attention that, unlike `Phoenix.HTML.Tag.tag/2` and `Phoenix.HTML.Tag.content_tag/2`, this
+  Pay attention that, unlike `tag/2` and `content_tag/2`, this
   function does not sort the attributes.
 
       iex> attributes_escape(title: "the title", id: "the id", selected: true)


### PR DESCRIPTION
This PR adds a new function called `attributes_escape/1` that will be used by the new template engine I'm working on. I'm not sure this function should be placed in the `Tag` module since neither `tag` nor `content_tag` use it. However, I believe they should use it for consistency. The problem is that, currently, the implementation sorts the attributes, which makes no sense for the new engine as it generates groups of attributes separately based on their types (static key/value, static key + dynamic value and dynamic key/value). 

I can either move this function to someplace else or change the implementation of `tag` and `content_tag` to use it. The latter might break existing code if, for any reason, the order of the attributes was taken into account, for instance, in tests.