### PR TITLE
Phoenix should respect `event.preventDefault()` on links

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -47,6 +47,10 @@
   window.addEventListener("click", function(e) {
     var element = e.target;
 
+    if (e.defaultPrevented) {
+      return;
+    }
+
     while (element && element.getAttribute) {
       var phoenixLinkEvent = new PolyfillEvent('phoenix.link.click', {
         "bubbles": true, "cancelable": true


### PR DESCRIPTION
For example, `link("hello", to: "/world", onclick: "return false;")` should not do anything. Currently the fact that the default is already prevented when it reaches Phoenix's event handler is ignored.

