### PR TITLE
Fix CI on Elixir 1.11 (mix format)

### DIFF
--- a/test/phoenix_html/link_test.exs
+++ b/test/phoenix_html/link_test.exs
@@ -43,7 +43,11 @@ defmodule Phoenix.HTML.LinkTest do
                end
              )
 
-    assert safe_to_string(link(to: "/hello") do "world" end) == ~s[<a href="/hello">world</a>]
+    assert safe_to_string(
+             link(to: "/hello") do
+               "world"
+             end
+           ) == ~s[<a href="/hello">world</a>]
   end
 
   test "link with scheme" do


### PR DESCRIPTION
I noticed the tests on Elixir 1.11 were not running on CI because the job was failing on earlier formatting step, this should fix that.