### PR TITLE
Support nested phx-* attributes

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -179,8 +179,11 @@ defmodule Phoenix.HTML do
       iex> safe_to_string attributes_escape(title: "the title", id: "the id", selected: true)
       " title=\"the title\" id=\"the id\" selected"
 
-      iex> safe_to_string attributes_escape(%{data: [phx: [value: [foo: "bar"]]], class: "foo"})
-      " class=\"foo\" data-phx-value-foo=\"bar\""
+      iex> safe_to_string attributes_escape(%{data: [confirm: "Are you sure?"], class: "foo"})
+      " class=\"foo\" data-confirm=\"Are you sure?\""
+
+      iex> safe_to_string attributes_escape(%{phx: [value: [foo: "bar"]], class: "foo"})
+      " class=\"foo\" phx-value-foo=\"bar\""
 
   """
   def attributes_escape(attrs) when is_list(attrs) do
@@ -206,6 +209,9 @@ defmodule Phoenix.HTML do
   defp build_attrs([{"aria", v} | t]) when is_list(v),
     do: nested_attrs(v, " aria", t)
 
+  defp build_attrs([{"phx", v} | t]) when is_list(v),
+    do: nested_attrs(v, " phx", t)
+
   defp build_attrs([{"class", v} | t]) when is_list(v),
     do: [" class=\"", class_value(v), ?" | build_attrs(t)]
 
@@ -214,6 +220,9 @@ defmodule Phoenix.HTML do
 
   defp build_attrs([{:aria, v} | t]) when is_list(v),
     do: nested_attrs(v, " aria", t)
+
+  defp build_attrs([{:phx, v} | t]) when is_list(v),
+    do: nested_attrs(v, " phx", t)
 
   defp build_attrs([{:class, v} | t]) when is_list(v),
     do: [" class=\"", class_value(v), ?" | build_attrs(t)]

--- a/test/phoenix_html_test.exs
+++ b/test/phoenix_html_test.exs
@@ -77,11 +77,27 @@ defmodule Phoenix.HTMLTest do
     end
 
     test "handle nested data" do
-      assert attributes_escape([{"data", [a: "1", b: "2"]}]) |> safe_to_string() ==
+      assert attributes_escape([{"data", [{"a", "1"}, {"b", "2"}]}]) |> safe_to_string() ==
                ~s( data-a="1" data-b="2")
 
-      assert attributes_escape([{"aria", [a: "1", b: "2"]}]) |> safe_to_string() ==
+      assert attributes_escape([{:data, [a: "1", b: "2"]}]) |> safe_to_string() ==
+               ~s( data-a="1" data-b="2")
+
+      assert attributes_escape([{"aria", [{"a", "1"}, {"b", "2"}]}]) |> safe_to_string() ==
                ~s( aria-a="1" aria-b="2")
+
+      assert attributes_escape([{:aria, [a: "1", b: "2"]}]) |> safe_to_string() ==
+               ~s( aria-a="1" aria-b="2")
+
+      assert attributes_escape([{:phx, [click: "save", value: [user_id: 1, foo: :bar]]}])
+             |> safe_to_string() ==
+               ~s( phx-click="save" phx-value-user-id="1" phx-value-foo="bar")
+
+      assert attributes_escape([
+               {"phx", [{"click", "save"}, {"value", [{"user_id", 1}, {"foo", "bar"}]}]}
+             ])
+             |> safe_to_string() ==
+               ~s( phx-click="save" phx-value-user_id="1" phx-value-foo="bar")
     end
 
     test "handle class value as string" do


### PR DESCRIPTION
Similar to existing aria-* and data-* attributes support, allow for
passing nested phx-* attributes to tags.