### PR TITLE
Update Form.datetime_select/3 example to use H sigil

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1462,9 +1462,11 @@ defmodule Phoenix.HTML.Form do
 
       def my_datetime_select(form, field, opts \\ []) do
         builder = fn b ->
-          ~e"""
-          Date: <%= b.(:day, []) %> / <%= b.(:month, []) %> / <%= b.(:year, []) %>
-          Time: <%= b.(:hour, []) %> : <%= b.(:minute, []) %>
+          assigns = %{b: b}
+
+          ~H"""
+          Date: <%= @b.(:day, []) %> / <%= @b.(:month, []) %> / <%= @b.(:year, []) %>
+          Time: <%= @b.(:hour, []) %> : <%= @b.(:minute, []) %>
           """
         end
 


### PR DESCRIPTION
closes #363

`phoenix_html` doesn't depend on `phoenix_live_view` but it seems that this is the replacement for the deprecated `~e` sigil