### PR TITLE
Have `checkbox` use `value` only when `checked` needs to be determined

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -1055,16 +1055,14 @@ defmodule Phoenix.HTML.Form do
     # We html escape all values to be sure we are comparing
     # apples to apples. After all we may have true in the data
     # but "true" in the params and both need to match.
-    value = html_escape(value)
     checked_value = html_escape(checked_value)
     unchecked_value = html_escape(unchecked_value)
 
     opts =
-      if value == checked_value do
-        Keyword.put_new(opts, :checked, true)
-      else
-        opts
-      end
+      Keyword.put_new_lazy(opts, :checked, fn ->
+        value = html_escape(value)
+        value == checked_value
+      end)
 
     if hidden_input do
       hidden_opts = [type: "hidden", value: unchecked_value]

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -892,6 +892,18 @@ defmodule Phoenix.HTML.FormTest do
 
     assert safe_to_string(checkbox(:search, :key, value: 1, hidden_input: false)) ==
              ~s(<input id="search_key" name="search[key]" type="checkbox" value="true">)
+
+    # Mimick a field of type {:array, Ecto.Enum}, for which `field_value` returns an array of atoms:
+    assert safe_to_string(
+             checkbox(:search, :key,
+               name: "search[key][]",
+               value: [:a, :b],
+               checked_value: "c",
+               checked: false,
+               hidden_input: false
+             )
+           ) ==
+             ~s(<input id="search_key" name="search[key][]" type="checkbox" value="c">)
   end
 
   test "checkbox/3 with form" do


### PR DESCRIPTION
This is particularly useful for fields of type `{:array, Ecto.Enum}` which would fail to be converted to HTML:

```
** (ArgumentError) lists in Phoenix.HTML and templates may only contain integers representing bytes, binaries or other lists, got invalid entry: :a
```

I imagine that converting the items of `value` to HTML and setting `checked` according to if `checked_value in value` would be deemed too much.

I'm happy to compute `checked` myself, but I believe that having to pass a bogus `value` parameter for the code not to crash is a bug.

Note that this PR introduces a potential behavior change for:
```
checkbox(..., value: "a", checked_value: "a", checked: false)
````

Current behavior overrides the `checked` to `true` while this PR maintains the explicitly given value of `false`. It seems better to me, but not by much as this example seems illogical.
