### PR TITLE
Implement Phoenix.HTML.Safe for URI

### DIFF
--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -98,3 +98,7 @@ defimpl Phoenix.HTML.Safe, for: Tuple do
   def to_iodata({:safe, data}), do: data
   def to_iodata(value), do: raise(Protocol.UndefinedError, protocol: @protocol, value: value)
 end
+
+defimpl Phoenix.HTML.Safe, for: URI do
+  def to_iodata(data), do: Phoenix.HTML.Engine.html_escape(URI.to_string(data))
+end

--- a/test/phoenix_html/safe_test.exs
+++ b/test/phoenix_html/safe_test.exs
@@ -61,4 +61,15 @@ defmodule Phoenix.HTML.SafeTest do
 
     assert Safe.to_iodata(datetime) == "2000-01-01T12:13:14+00:30"
   end
+
+  test "impl for URI" do
+    uri = %URI{scheme: "http", host: "www.example.org", path: "/foo", query: "secret=<a&b>"}
+
+    expected = [
+      [[[], "http://www.example.org/foo?secret=" | "&lt;"], "a" | "&amp;"],
+      "b" | "&gt;"
+    ]
+
+    assert Safe.to_iodata(uri) == expected
+  end
 end


### PR DESCRIPTION
Right now, `URI` values cannot be interpolated in templates directly. For example, this function

```elixir
def f() do
  uri = %URI{ ... }

  assigns = %{uri: uri}
  ~H"""
    <a href={@uri}>foo</a>
  ""
end
```

Runs into

```
  ** (Protocol.UndefinedError) protocol Phoenix.HTML.Safe not implemented for %URI ...
```

To work around this, clients currently have to convert the `URI` to a string, i.e.

```elixir
  assigns = %{uri: to_string(uri)}
```

This patch attempts to make Phoenix a little bit more gentle by having it provide a plausible definition of `Phoenix.HTML.Safe` for `URI` values, hopefully removing the need for clients to convert URIs to strings.