### PR TITLE
Use `defdelegate` for HTML.Safe implementations of Integer and Float

### DIFF
--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -85,13 +85,11 @@ defimpl Phoenix.HTML.Safe, for: List do
 end
 
 defimpl Phoenix.HTML.Safe, for: Integer do
-  def to_iodata(data), do: Integer.to_string(data)
+  defdelegate to_iodata(data), to: Integer, as: :to_string
 end
 
 defimpl Phoenix.HTML.Safe, for: Float do
-  def to_iodata(data) do
-    IO.iodata_to_binary(:io_lib_format.fwrite_g(data))
-  end
+  defdelegate to_iodata(data), to: Float, as: :to_string
 end
 
 defimpl Phoenix.HTML.Safe, for: Tuple do


### PR DESCRIPTION
While looking at the changes made in #383 I noticed `defdelegate` being used in the implementations of `BitString`, `Time`, `Date` and `NaiveDateTime` and thought it would be nice if the one for `Integer` would do the same.

And, since the current implementation for `Float` is just the code of [`Float.to_string/1`](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/float.ex#L562) copied over, I delegated to that one too.

Feel free to close if you don't like it, just a quick thought I had. ☺️