### PR TITLE
Clarifying note

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -625,6 +625,9 @@ defmodule Phoenix.HTML.Form do
 
   @doc """
   Generates hidden inputs for the given form.
+
+  These include things like `:id` fields, which are included for existing
+  records and skipped for new ones.
   """
   @spec hidden_inputs_for(t) :: list(Phoenix.HTML.safe())
   def hidden_inputs_for(form) do


### PR DESCRIPTION
Can somebody help me write a better or more complete explanation? I used `hidden_input f, :id` inside an `inputs_for` and didn't get that I needed to use `hidden_inputs_for` so that `:id` would not be included on dynamically generated rows for adding new records.