### PR TITLE
Fixes CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             otp: 23.3
             lint: lint
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout


### PR DESCRIPTION
I think the reason why `master` is currently failing is because...

GitHub Actions switched `ubuntu-latest` from `ubuntu-20.04` to `ubuntu-20.04` in the last month or so
(https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/) and the currently used OTP versions in `ci.yml` are not compatible with what comes in `ubuntu-22.04` by default
(https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp).