### PR TITLE
fixes csrf token and _method inputs visibility

### DIFF
--- a/lib/phoenix_html/tag.ex
+++ b/lib/phoenix_html/tag.ex
@@ -171,8 +171,11 @@ defmodule Phoenix.HTML.Tag do
         _ ->
           {csrf, opts} = csrf_form_tag(action, opts)
 
-          {[~s'<input name="_method" type="hidden" value="', to_string(method), ~s'">' | csrf],
-           Keyword.put(opts, :method, "post")}
+          {[
+             ~s'<input name="_method" type="hidden" hidden value="',
+             to_string(method),
+             ~s'">' | csrf
+           ], Keyword.put(opts, :method, "post")}
       end
 
     opts =
@@ -203,11 +206,14 @@ defmodule Phoenix.HTML.Tag do
   defp csrf_form_tag(to, opts) do
     case Keyword.pop(opts, :csrf_token, true) do
       {csrf_token, opts} when is_binary(csrf_token) ->
-        {[~s'<input name="#{@csrf_param}" type="hidden" value="', csrf_token, ~s'">'], opts}
+        {[~s'<input name="#{@csrf_param}" type="hidden" hidden value="', csrf_token, ~s'">'],
+         opts}
 
       {true, opts} ->
         csrf_token = csrf_token_value(to)
-        {[~s'<input name="#{@csrf_param}" type="hidden" value="', csrf_token, ~s'">'], opts}
+
+        {[~s'<input name="#{@csrf_param}" type="hidden" hidden value="', csrf_token, ~s'">'],
+         opts}
 
       {false, opts} ->
         {[], opts}

--- a/test/phoenix_html/csrf_test.exs
+++ b/test/phoenix_html/csrf_test.exs
@@ -23,15 +23,15 @@ defmodule Phoenix.HTML.CSRFTest do
   test "form_tag for post using a custom csrf token" do
     assert safe_to_string(form_tag("/")) =~ ~r(
                 <form\ action="/"\ method="post">
-                <input\ name="_csrf_token"\ type="hidden"\ value="[^"]+">
+                <input\ name="_csrf_token"\ type="hidden"\ hidden\ value="[^"]+">
               )mx
   end
 
   test "form_tag for other method using a custom csrf token" do
     assert safe_to_string(form_tag("/", method: :put)) =~ ~r(
                 <form\ action="/"\ method="post">
-                <input\ name="_method"\ type="hidden"\ value="put">
-                <input\ name="_csrf_token"\ type="hidden"\ value="[^"]+">
+                <input\ name="_method"\ type="hidden"\ hidden\ value="put">
+                <input\ name="_csrf_token"\ type="hidden"\ hidden\ value="[^"]+">
               )mx
   end
 end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -86,7 +86,7 @@ defmodule Phoenix.HTML.FormTest do
       assert form =~
                ~s(<form action="/" enctype="multipart/form-data" method="post">)
 
-      assert form =~ ~s(<input name="_method" type="hidden" value="put">)
+      assert form =~ ~s(<input name="_method" type="hidden" hidden value="put">)
     end
 
     test "is html safe" do
@@ -171,7 +171,7 @@ defmodule Phoenix.HTML.FormTest do
       assert form =~
                ~s(<form action="/" enctype="multipart/form-data" method="post">)
 
-      assert form =~ ~s(<input name="_method" type="hidden" value="put">)
+      assert form =~ ~s(<input name="_method" type="hidden" hidden value="put">)
     end
 
     test "is html safe" do

--- a/test/phoenix_html/tag_test.exs
+++ b/test/phoenix_html/tag_test.exs
@@ -126,7 +126,7 @@ defmodule Phoenix.HTML.TagTest do
 
     assert safe_to_string(form_tag("/")) ==
              ~s(<form action="/" method="post">) <>
-               ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">)
+               ~s(<input name="_csrf_token" type="hidden" hidden value="#{csrf_token}">)
 
     assert safe_to_string(form_tag("/", method: :post, csrf_token: false, multipart: true)) ==
              ~s(<form action="/" enctype="multipart/form-data" method="post">)
@@ -137,8 +137,8 @@ defmodule Phoenix.HTML.TagTest do
 
     assert safe_to_string(form_tag("/", method: :put)) ==
              ~s(<form action="/" method="post">) <>
-               ~s(<input name="_method" type="hidden" value="put">) <>
-               ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">)
+               ~s(<input name="_method" type="hidden" hidden value="put">) <>
+               ~s(<input name="_csrf_token" type="hidden" hidden value="#{csrf_token}">)
   end
 
   test "form_tag with do block" do
@@ -150,7 +150,7 @@ defmodule Phoenix.HTML.TagTest do
              end
            ) ==
              ~s(<form action="/" method="post">) <>
-               ~s(<input name="_csrf_token" type="hidden" value="#{csrf_token}">) <>
+               ~s(<input name="_csrf_token" type="hidden" hidden value="#{csrf_token}">) <>
                ~s(&lt;&gt;) <> ~s(</form>)
 
     assert safe_to_string(


### PR DESCRIPTION
- fix: add hidden attr to csrf inputs https://github.com/phoenixframework/phoenix/issues/5197
