### PR TITLE
Use field atom for input_value

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -284,7 +284,7 @@ defmodule Phoenix.HTML.Form do
        form: form,
        id: input_id(form, field_as_string),
        name: input_name(form, field_as_string),
-       value: input_value(form, field_as_string)
+       value: input_value(form, field)
      }}
   end
 

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -384,11 +384,9 @@ defmodule Phoenix.HTML.Form do
         field
       )
       when is_atom(field) do
-    as_string = Atom.to_string(field)
-
     impl1 != impl2 or id1 != id2 or name1 != name2 or
       Keyword.get_values(errors1, field) != Keyword.get_values(errors2, field) or
-      impl1.input_value(source1, form1, as_string) != impl2.input_value(source2, form2, as_string)
+      impl1.input_value(source1, form1, field) != impl2.input_value(source2, form2, field)
   end
 
   @doc """


### PR DESCRIPTION
Fixes implementations (like phoenix_ecto) that expect a field atom to derive value.