### PR TITLE
Allow string keys in form access

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -276,12 +276,13 @@ defmodule Phoenix.HTML.Form do
 
   @doc false
   def fetch(%Form{errors: errors} = form, field) when is_atom(field) do
-    field_as_string = Atom.to_string(field)
+    field_as_string = field_to_string(field)
+    field_as_atom = field_to_atom(field)
 
     {:ok,
      %Phoenix.HTML.FormField{
-       errors: Keyword.get_values(errors, field),
-       field: field,
+       errors: Keyword.get_values(errors, field_as_atom),
+       field: field_as_atom,
        form: form,
        id: input_id(form, field_as_string),
        name: input_name(form, field_as_string),
@@ -1865,4 +1866,7 @@ defmodule Phoenix.HTML.Form do
   # Normalize field name to string version
   defp field_to_string(field) when is_atom(field), do: Atom.to_string(field)
   defp field_to_string(field) when is_binary(field), do: field
+
+  defp field_to_atom(field) when is_atom(field), do: field
+  defp field_to_atom(field) when is_binary(field), do: String.to_existing_atom(field)
 end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -225,7 +225,7 @@ defmodule Phoenix.HTML.FormTest do
   end
 
   describe "access" do
-    test "without name" do
+    test "atom key without name" do
       form = form(%{"key" => "value"})
 
       assert form[:key] == %Phoenix.HTML.FormField{
@@ -238,7 +238,33 @@ defmodule Phoenix.HTML.FormTest do
              }
     end
 
-    test "with name" do
+    test "atom key with name" do
+      form = form(%{"key" => "value"}, as: :search)
+
+      assert form[:key] == %Phoenix.HTML.FormField{
+               field: :key,
+               id: "search_key",
+               form: form,
+               value: "value",
+               name: "search[key]",
+               errors: []
+             }
+    end
+
+    test "string key without name" do
+      form = form(%{"key" => "value"})
+
+      assert form[:key] == %Phoenix.HTML.FormField{
+               field: :key,
+               id: "key",
+               form: form,
+               value: "value",
+               name: "key",
+               errors: []
+             }
+    end
+
+    test "string key with name" do
       form = form(%{"key" => "value"}, as: :search)
 
       assert form[:key] == %Phoenix.HTML.FormField{


### PR DESCRIPTION
Hello,

I'm just dipping my toes into contributing outside of just doc fixes so I thought I'd grab [this issue](https://github.com/phoenixframework/phoenix_live_view/issues/2438).  I got the insight from a comment made by [JohnnyCurran](https://elixirforum.com/u/JohnnyCurran) on Elixir Forums.  Maybe I'm way off base here but thought I'd open the PR.

Thanks!