### PR TITLE
Document form[field] access quirks

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -14,7 +14,7 @@ defmodule Phoenix.HTML.Form do
   The field name can be either an atom or a string. If it is an atom,
   it assumes the form keeps both data and errors as atoms. If it is a
   string, it considers data and errors are stored as strings for said
-  field.
+  field. Forms backed by an `Ecto.Changeset` only support atom field names.
   """
 
   alias Phoenix.HTML.Form

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -15,6 +15,10 @@ defmodule Phoenix.HTML.Form do
   it assumes the form keeps both data and errors as atoms. If it is a
   string, it considers data and errors are stored as strings for said
   field. Forms backed by an `Ecto.Changeset` only support atom field names.
+
+  It is possible to "access" fields which do not exist in the source data
+  structure. A `Phoenix.HTML.FormField` struct will be dynamically created
+  with some attributes such as `name` and `id` populated.
   """
 
   alias Phoenix.HTML.Form


### PR DESCRIPTION
>  field. Forms backed by an `Ecto.Changeset` only support atom field names.

The form handles the string fine, but the ecto formdata implementation raises on non atom keys.

Per:

```elixir
 defp fetch(%{errors: errors} = form, field, field_as_string) do
    {:ok,
     %Phoenix.HTML.FormField{
       errors: for({^field, value} <- errors, do: value),
       field: field,
       form: form,
       id: input_id(form, field_as_string),
       name: input_name(form, field_as_string),
       value: input_value(form, field) # <- THIS CALL
     }}
  end
```

and

```elixir
    def input_value(_data, _form, field) do
      raise ArgumentError, "expected field to be an atom, got: #{inspect(field)}"
    end
```

https://github.com/phoenixframework/phoenix_ecto/blob/c68548d8d2dd904cbb7e43cf10b11076b92df91d/lib/phoenix_ecto/html.ex#L121-L123

>  It is possible to "access" fields which do not exist in the source data structure. A `Phoenix.HTML.FormField` struct will be dynamically created with some attributes such as `name` and `id` populated.

A useful quirk/feature that may also catch some people out.