### PR TITLE
Add support for lists of atoms

### DIFF
--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -73,13 +73,17 @@ defimpl Phoenix.HTML.Safe, for: List do
     Phoenix.HTML.Engine.html_escape(h)
   end
 
+  def to_iodata(h) when is_atom(h) do
+    Phoenix.HTML.Engine.html_escape(Atom.to_string(h))
+  end
+
   def to_iodata({:safe, data}) do
     data
   end
 
   def to_iodata(other) do
     raise ArgumentError,
-          "lists in Phoenix.HTML and templates may only contain integers representing bytes, binaries or other lists, " <>
+          "lists in Phoenix.HTML and templates may only contain integers representing atoms, bytes, binaries or other lists, " <>
             "got invalid entry: #{inspect(other)}"
   end
 end

--- a/test/phoenix_html/safe_test.exs
+++ b/test/phoenix_html/safe_test.exs
@@ -39,6 +39,11 @@ defmodule Phoenix.HTML.SafeTest do
     assert Safe.to_iodata(date) == "2000-01-01"
   end
 
+  test "impl for List of atom" do
+    list = [:foo, :bar]
+    assert Safe.to_iodata(list) == ["foo", "bar"]
+  end
+
   test "impl for NaiveDateTime" do
     {:ok, datetime} = NaiveDateTime.new(2000, 1, 1, 12, 13, 14)
     assert Safe.to_iodata(datetime) == "2000-01-01T12:13:14"


### PR DESCRIPTION
Original discussion: https://elixirforum.com/t/trouble-rendering-ecto-enum-array-in-liveview/55701

This PR should add support for rendering lists of atoms (i.e. if one of your schema's fields is an array of `Ecto.Enum`)

Added a test, tested in my own phoenix project and this fixes the error. 😄 