### PR TITLE
Update docs to note that form/1 is preferred over form_for/4

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -402,7 +402,7 @@ defmodule Phoenix.HTML.Form do
 
   Note that if you are using Phoenix LiveView, `form_for/4` is no longer the
   preferred way to generate a form tag, and you should use
-  [Phoenix.Component.form/1](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#form/1)
+  [`Phoenix.Component.form/1`](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#form/1)
   instead.
 
   ## With changeset data

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -400,6 +400,11 @@ defmodule Phoenix.HTML.Form do
 
   We will explore all them below.
 
+  Note that if you are using Phoenix LiveView, `form_for/4` is no longer the
+  preferred way to generate a form tag, and you should use
+  [Phoenix.Component.form/1](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#form/1)
+  instead.
+
   ## With changeset data
 
   The entry point for defining forms in Phoenix is with


### PR DESCRIPTION
This was discussed in the Elixir Slack recently and I think it's worth making the docs clearer because it was a big point of confusion for me:

![form_for_slack_conversation](https://github.com/phoenixframework/phoenix_html/assets/85154056/b8c34009-2dc0-4bbd-8f3b-339af0e7ce53)
