### PR TITLE
Resolve core-js module conflict for input name attribute

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -19,7 +19,7 @@
   function buildHiddenInput(name, value) {
     var input = document.createElement("input");
     input.type = "hidden";
-    input.name = name;
+    input.setAttribute("name", name);
     input.value = value;
     return input;
   }


### PR DESCRIPTION
I found a conflict when using Babel and core-js alongside phoenix-html. The `buildHiddenInput` function in phoenix_html.js tries to set the name attribute of input element using dot notation `(i.e., input.name = name;)`. This triggers error about a missing module (core-js/modules/es.function.name.js), shows interference from polyfills. 

This suggests there's a polyfill being applied for the `.name` property of functions. However, in the context of `buildHiddenInput` function, it’s trying to set the .name property of an input element, not access the .name property of a function. It's possible that the polyfill is interfering here.

By adopting `setAttribute`, it can bypass this issue and ensure the attribute is assigned without any issue from the polyfills. `input.setAttribute("name", name);`