### PR TITLE
Require a data-to with the data-method before the click handler triggers a HTTP request 

### DIFF
--- a/priv/static/phoenix_html.js
+++ b/priv/static/phoenix_html.js
@@ -65,7 +65,7 @@
         return false;
       }
 
-      if (element.getAttribute("data-method")) {
+      if (element.getAttribute("data-method") && element.getAttribute("data-to")) {
         handleClick(element, e.metaKey || e.shiftKey);
         e.preventDefault();
         return false;


### PR DESCRIPTION
We recently ran into a conflict with a third party js library that uses the `data-method` attribute on elements to signal which function should handle its events. The javascript bundled with `phoenix_html` also does a HTTP POST together with this non-sensical method attribute as a side effect.

The docs here might be misleading:
```
Support data-method="patch|post|put|delete" attributes, which sends the current click as a PATCH/POST/PUT/DELETE HTTP request. You will need to add data-to with the URL and data-csrf with the CSRF token value
```
as that would suggest that only valid HTTP request types are being handled, while instead every custom method results in a POST as well.

So I decided to restrict this to only trigger click handling when the `data-method` is indeed one of the aforementioned types. 