### PR TITLE
Add type to Phoenix.HTML.FormField

### DIFF
--- a/lib/phoenix_html/form_field.ex
+++ b/lib/phoenix_html/form_field.ex
@@ -12,6 +12,15 @@ defmodule Phoenix.HTML.FormField do
     * `:value` - the value for the input
 
   """
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          errors: [term],
+          field: Phoenix.HTML.Form.field(),
+          form: Phoenix.HTML.Form.t(),
+          value: term
+        }
+
   @enforce_keys [:id, :name, :errors, :field, :form, :value]
   defstruct [:id, :name, :errors, :field, :form, :value]
 end


### PR DESCRIPTION
Adds a type to Phoenix.HTML.FormField, allowing use of the type instead of the struct in typespecs

Related Credo warning: [SpecWithStruct](https://hexdocs.pm/credo/Credo.Check.Warning.SpecWithStruct.html)