### PR TITLE
Add `Phoenix.HTML.Safe` to Duration

### DIFF
--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -44,8 +44,10 @@ defimpl Phoenix.HTML.Safe, for: DateTime do
   end
 end
 
-defimpl Phoenix.HTML.Safe, for: Duration do
-  defdelegate to_iodata(data), to: Duration, as: :to_iso8601
+if Code.ensure_loaded?(Duration) do
+  defimpl Phoenix.HTML.Safe, for: Duration do
+    defdelegate to_iodata(data), to: Duration, as: :to_iso8601
+  end
 end
 
 defimpl Phoenix.HTML.Safe, for: List do

--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -44,6 +44,10 @@ defimpl Phoenix.HTML.Safe, for: DateTime do
   end
 end
 
+defimpl Phoenix.HTML.Safe, for: Duration do
+  defdelegate to_iodata(data), to: Duration, as: :to_iso8601
+end
+
 defimpl Phoenix.HTML.Safe, for: List do
   def to_iodata(list), do: recur(list)
 

--- a/test/phoenix_html/safe_test.exs
+++ b/test/phoenix_html/safe_test.exs
@@ -62,9 +62,11 @@ defmodule Phoenix.HTML.SafeTest do
     assert Safe.to_iodata(datetime) == "2000-01-01T12:13:14+00:30"
   end
 
-  test "impl for Duration" do
-    duration = Duration.new!(month: 1)
-    assert Safe.to_iodata(duration) == "P1M"
+  if Code.ensure_loaded?(Duration) do
+    test "impl for Duration" do
+      duration = Duration.new!(month: 1)
+      assert Safe.to_iodata(duration) == "P1M"
+    end
   end
 
   test "impl for URI" do

--- a/test/phoenix_html/safe_test.exs
+++ b/test/phoenix_html/safe_test.exs
@@ -62,6 +62,11 @@ defmodule Phoenix.HTML.SafeTest do
     assert Safe.to_iodata(datetime) == "2000-01-01T12:13:14+00:30"
   end
 
+  test "impl for Duration" do
+    duration = Duration.new!(month: 1)
+    assert Safe.to_iodata(duration) == "P1M"
+  end
+
   test "impl for URI" do
     uri = %URI{scheme: "http", host: "www.example.org", path: "/foo", query: "secret=<a&b>"}
 


### PR DESCRIPTION
I was creating a form which had a set of options, the values being durations

```elixir
<.input
  label="Duration"
  field={@form[:duration]}
  type="select"
  options={[
    {"Daily", Duration.new!(day: 1)},
    {"Weekly", Duration.new!(week: 1)},
    {"Monthly", Duration.new!(month: 1)},
    {"Yearly", Duration.new!(year: 1)}
  ]}
/>
```

`Duration` has `to_iso8601` and `from_iso8601` functions so I assumed this would work like `Date` and `Time` does (auto converts to ISO), but `Phoenix.HTML.Safe` hadn't been implemented for Duration causing this error: `protocol Phoenix.HTML.Safe not implemented for type Duration (a struct).`

This PR adds the `Phoenix.HTML.Safe` implentation. Their might of been a reason why this wasn't added originally though, but im not too sure why that could be?