### PR TITLE
Fix form file input normalized value

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -268,6 +268,10 @@ defmodule Phoenix.HTML.Form do
     html_escape(value) == {:safe, "true"}
   end
 
+  def normalize_value("file", _value) do
+    ""
+  end
+
   def normalize_value(_type, value) do
     value
   end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -115,6 +115,10 @@ defmodule Phoenix.HTML.FormTest do
       assert safe_to_string(normalize_value("textarea", nil)) == "\n"
     end
 
+    test "for file" do
+      assert normalize_value("file", "<any>") == ""
+    end
+
     test "for anything else" do
       assert normalize_value("foo", "<other>") == "<other>"
     end


### PR DESCRIPTION
Set form file input normalized value to empty string
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file#value