### PR TITLE
Allow structs as select option values

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -391,7 +391,8 @@ defmodule Phoenix.HTML.Form do
   end
 
   defp option(group_label, group_values, extra, value)
-       when is_list(group_values) or is_map(group_values) do
+       when is_list(group_values) or
+              (is_map(group_values) and not is_map_key(group_values, :__struct__)) do
     section_options = escaped_options_for_select(group_values, value, extra)
     option_tag("optgroup", [label: group_label], {:safe, section_options})
   end

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -293,6 +293,19 @@ defmodule Phoenix.HTML.FormTest do
                ~s(<option value="value">Label</option>) <>
                  ~s(<hr/>) <>
                  ~s(<option value="new">New</option>)
+
+      assert options_for_select(
+               [
+                 {"Open", ~U[2025-01-01 06:30:00.000000Z]},
+                 {"Close", ~U[2025-01-01 18:30:00.000000Z]}
+               ],
+               [
+                 ~U[2025-01-01 06:30:00.000000Z]
+               ]
+             )
+             |> safe_to_string() ==
+               ~s(<option selected value="2025-01-01T06:30:00.000000Z">Open</option>) <>
+                 ~s(<option value="2025-01-01T18:30:00.000000Z">Close</option>)
     end
 
     test "with custom option tag" do


### PR DESCRIPTION
### Issue

If I try to use a select with struct values, I get an error because of an `is_map` check, and assumes that it is an option group.

We should be able to pass as values any struct that implements the `Phoenix.HTML.Safe` protocol.

### Changes

- added a struct check
- added a new test assertion that fails without this fix:

```
  1) test options_for_select/2 simple (Phoenix.HTML.FormTest)
     test/phoenix_html/form_test.exs:262
     ** (Protocol.UndefinedError) protocol Enumerable not implemented for type DateTime (a struct).
     This protocol is implemented for the following type(s): Date.Range, File.Stream, Function,
     GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream

     Got value:

         ~U[2025-01-01 06:30:00.000000Z]

     code: assert options_for_select([
        {"Open", ~U[2025-01-01 06:30:00.000000Z]},
        {"Close", ~U[2025-01-01 18:30:00.000000Z]}
      ], [
     stacktrace:
       (elixir 1.18.4) lib/enum.ex:1: Enumerable.impl_for!/1
       (elixir 1.18.4) lib/enum.ex:166: Enumerable.reduce/3
       (elixir 1.18.4) lib/enum.ex:4515: Enum.reduce/3
       (phoenix_html 4.2.1) lib/phoenix_html/form.ex:395: Phoenix.HTML.Form.option/4
       (phoenix_html 4.2.1) lib/phoenix_html/form.ex:360: anonymous fn/4 in 
        Phoenix.HTML.Form.escaped_options_for_select/3
       (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
       (phoenix_html 4.2.1) lib/phoenix_html/form.ex:347: Phoenix.HTML.Form.options_for_select/3
       test/phoenix_html/form_test.exs:306: (test)
```