### PR TITLE
Handle :hr in keyword lists

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -380,7 +380,11 @@ defmodule Phoenix.HTML.Form do
               {value, options}
           end
 
-        [acc | option(option_key, option_value, extra ++ options, selected_values)]
+        if option_key == :hr do
+          [acc | hr_tag()]
+        else
+          [acc | option(option_key, option_value, extra ++ options, selected_values)]
+        end
 
       :hr, acc ->
         [acc | hr_tag()]

--- a/test/phoenix_html/form_test.exs
+++ b/test/phoenix_html/form_test.exs
@@ -296,6 +296,19 @@ defmodule Phoenix.HTML.FormTest do
 
       assert options_for_select(
                [
+                 [key: "First", value: "first"],
+                 [key: :hr, value: nil],
+                 [key: "Last", value: "last"]
+               ],
+               nil
+             )
+             |> safe_to_string() ==
+               ~s(<option value="first">First</option>) <>
+                 ~s(<hr/>) <>
+                 ~s(<option value="last">Last</option>)
+
+      assert options_for_select(
+               [
                  {"Open", ~U[2025-01-01 06:30:00.000000Z]},
                  {"Close", ~U[2025-01-01 18:30:00.000000Z]}
                ],


### PR DESCRIPTION
This fixes an issue where the `:hr` special case isn't handled by `options_for_select` when passing in a keyword list.