### PR TITLE
feat/atomvm-phoenix-micro-example

### DIFF
--- a/lib/phoenix_html.ex
+++ b/lib/phoenix_html.ex
@@ -292,9 +292,16 @@ defmodule Phoenix.HTML do
     |> Enum.join(" ")
   end
 
-  defp key_escape(value) when is_atom(value), do: String.replace(Atom.to_string(value), "_", "-")
+  # AtomVM has no Elixir.String; avoid String.replace/3 for attribute key mapping.
+  defp key_escape(value) when is_atom(value), do: underscore_to_dash(Atom.to_string(value))
   defp key_escape(value) when is_binary(value), do: validate_attr_name!(value)
   defp key_escape(value), do: attr_escape(value)
+
+  defp underscore_to_dash(bin) when is_binary(bin) do
+    for <<c <- bin>>, into: <<>> do
+      if c == ?_, do: <<?->>, else: <<c>>
+    end
+  end
 
   @invalid_attr_chars ~c"\"'>/="
 
@@ -387,10 +394,15 @@ defmodule Phoenix.HTML do
     # This is a direct translation of
     # https://github.com/mathiasbynens/CSS.escape/blob/master/css.escape.js
     # into Elixir.
+    # Avoid String.to_charlist/1 for AtomVM (no Elixir.String module).
     value
-    |> String.to_charlist()
+    |> utf8_charlist()
     |> escape_css_chars()
     |> IO.iodata_to_binary()
+  end
+
+  defp utf8_charlist(bin) when is_binary(bin) do
+    for <<c::utf8 <- bin>>, do: c
   end
 
   defp escape_css_chars(chars) do

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -167,9 +167,23 @@ defmodule Phoenix.HTML.Form do
   @spec input_id(t | atom, field, Phoenix.HTML.Safe.t()) :: String.t()
   def input_id(name, field, value) do
     {:safe, value} = html_escape(value)
-    value_id = value |> IO.iodata_to_binary() |> String.replace(~r/\W/u, "_")
+    # Avoid String.replace/3 + Regex for AtomVM (no Elixir.String module).
+    # Approximate ~r/\W/u by replacing non [A-Za-z0-9_] codepoints with "_".
+    value_id = value |> IO.iodata_to_binary() |> non_word_to_underscore()
     input_id(name, field) <> "_" <> value_id
   end
+
+  defp non_word_to_underscore(bin) when is_binary(bin) do
+    for <<c::utf8 <- bin>>, into: <<>> do
+      if word_char?(c), do: <<c::utf8>>, else: <<?_>>
+    end
+  end
+
+  defp word_char?(c) when c in ?0..?9, do: true
+  defp word_char?(c) when c in ?A..?Z, do: true
+  defp word_char?(c) when c in ?a..?z, do: true
+  defp word_char?(?_), do: true
+  defp word_char?(_), do: false
 
   @doc """
   Returns a name of a corresponding form field.

--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -90,21 +90,41 @@ defmodule Phoenix.HTML.Form do
 
   @type field :: atom | String.t()
 
+  def fetch_field(%Form{} = form, field) when is_atom(field) or is_binary(field) do
+    {:ok, field_struct} = fetch(form, field)
+    field_struct
+  end
+
+  @behaviour Access
+
   @doc false
+  @impl Access
   def fetch(%Form{} = form, field) when is_atom(field) do
-    fetch(form, field, Atom.to_string(field))
+    build_form_field(form, field, Atom.to_string(field))
   end
 
+  @impl Access
   def fetch(%Form{} = form, field) when is_binary(field) do
-    fetch(form, field, field)
+    build_form_field(form, field, field)
   end
 
+  @impl Access
   def fetch(%Form{}, field) do
     raise ArgumentError,
           "accessing a form with form[field] requires the field to be an atom or a string, got: #{inspect(field)}"
   end
 
-  defp fetch(%{errors: errors} = form, field, field_as_string) do
+  @impl Access
+  def get_and_update(_form, _key, _fun) do
+    raise ArgumentError, "cannot get_and_update keys from a Phoenix.HTML.Form"
+  end
+
+  @impl Access
+  def pop(_form, _key) do
+    raise ArgumentError, "cannot pop keys from a Phoenix.HTML.Form"
+  end
+
+  defp build_form_field(%{errors: errors} = form, field, field_as_string) do
     {:ok,
      %Phoenix.HTML.FormField{
        errors: field_errors(errors, field),
@@ -428,9 +448,13 @@ defmodule Phoenix.HTML.Form do
     [?<, "hr", ?/, ?>]
   end
 
-  # Helper for getting field errors, handling string fields
+  # Helper for getting field errors, handling string fields.
+  # AtomVM: avoid `for` comprehensions (elixir_erl_pass).
   defp field_errors(errors, field)
        when is_list(errors) and (is_atom(field) or is_binary(field)) do
-    for {^field, error} <- errors, do: error
+    Enum.flat_map(errors, fn
+      {^field, error} -> [error]
+      _ -> []
+    end)
   end
 end

--- a/lib/phoenix_html/safe.ex
+++ b/lib/phoenix_html/safe.ex
@@ -24,23 +24,32 @@ defimpl Phoenix.HTML.Safe, for: BitString do
   defdelegate to_iodata(data), to: Phoenix.HTML.Engine, as: :html_escape
 end
 
-defimpl Phoenix.HTML.Safe, for: Time do
-  defdelegate to_iodata(data), to: Time, as: :to_iso8601
+# Guard calendar/URI impls: AtomVM may not ship these modules.
+if Code.ensure_loaded?(Time) do
+  defimpl Phoenix.HTML.Safe, for: Time do
+    defdelegate to_iodata(data), to: Time, as: :to_iso8601
+  end
 end
 
-defimpl Phoenix.HTML.Safe, for: Date do
-  defdelegate to_iodata(data), to: Date, as: :to_iso8601
+if Code.ensure_loaded?(Date) do
+  defimpl Phoenix.HTML.Safe, for: Date do
+    defdelegate to_iodata(data), to: Date, as: :to_iso8601
+  end
 end
 
-defimpl Phoenix.HTML.Safe, for: NaiveDateTime do
-  defdelegate to_iodata(data), to: NaiveDateTime, as: :to_iso8601
+if Code.ensure_loaded?(NaiveDateTime) do
+  defimpl Phoenix.HTML.Safe, for: NaiveDateTime do
+    defdelegate to_iodata(data), to: NaiveDateTime, as: :to_iso8601
+  end
 end
 
-defimpl Phoenix.HTML.Safe, for: DateTime do
-  def to_iodata(data) do
-    # Call escape in case someone can inject reserved
-    # characters in the timezone or its abbreviation
-    Phoenix.HTML.Engine.html_escape(DateTime.to_iso8601(data))
+if Code.ensure_loaded?(DateTime) do
+  defimpl Phoenix.HTML.Safe, for: DateTime do
+    def to_iodata(data) do
+      # Call escape in case someone can inject reserved
+      # characters in the timezone or its abbreviation
+      Phoenix.HTML.Engine.html_escape(DateTime.to_iso8601(data))
+    end
   end
 end
 
@@ -100,6 +109,8 @@ defimpl Phoenix.HTML.Safe, for: Tuple do
   def to_iodata(value), do: raise(Protocol.UndefinedError, protocol: @protocol, value: value)
 end
 
-defimpl Phoenix.HTML.Safe, for: URI do
-  def to_iodata(data), do: Phoenix.HTML.Engine.html_escape(URI.to_string(data))
+if Code.ensure_loaded?(URI) do
+  defimpl Phoenix.HTML.Safe, for: URI do
+    def to_iodata(data), do: Phoenix.HTML.Engine.html_escape(URI.to_string(data))
+  end
 end


### PR DESCRIPTION
## Summary

- Replace String-dependent HTML helpers with binary-based implementations
- Make Form.field_errors AtomVM-safe without elixir_erl_pass
- Keep the :phoenix_html app name so Phoenix apps can override Hex phoenix_html
- Support phoenix_micro_example scaffold templates and forms on AtomVM