### PR TITLE
Fix "idiosyncracies" typo in Phoenix.HTML.Form docs

### DIFF
--- a/lib/phoenix_html/form.ex
+++ b/lib/phoenix_html/form.ex
@@ -238,7 +238,7 @@ defmodule Phoenix.HTML.Form do
   @doc """
   Normalizes an input `value` according to its input `type`.
 
-  Certain HTML input values must be cast, or they will have idiosyncracies
+  Certain HTML input values must be cast, or they will have idiosyncrasies
   when they are rendered. The goal of this function is to encapsulate
   this logic. In particular:
 


### PR DESCRIPTION
Fixes a small typo: "idiosyncracies" → "idiosyncrasies".